### PR TITLE
Declare workflowDispatch with inputs

### DIFF
--- a/packages/cdkactions/API.md
+++ b/packages/cdkactions/API.md
@@ -45,8 +45,18 @@ Name|Description
 [StrategyProps](#cdkactions-strategyprops)|Strategy configuration block.
 [StringMap](#cdkactions-stringmap)|A generic string to string map.
 [WatchTypes](#cdkactions-watchtypes)|Configuration for the Watch event.
+[WorkflowDispatchEvent](#cdkactions-workflowdispatchevent)|Configuration for the WorkflowDispatch event.
+[WorkflowDispatchEventInputProps](#cdkactions-workflowdispatcheventinputprops)|Configuration for a manually dispatched workflow input.
+[WorkflowDispatchEventProps](#cdkactions-workflowdispatcheventprops)|Configuration for the WorkflowDispatch event properties.
 [WorkflowProps](#cdkactions-workflowprops)|Configuration for a single GitHub Action workflow.
 [WorkflowRunEvent](#cdkactions-workflowrunevent)|Configuration for the WorkflowRun event.
+
+
+**Enums**
+
+Name|Description
+----|-----------
+[WorkflowDispatchInputType](#cdkactions-workflowdispatchinputtype)|Workflow dispatch input types.
 
 
 
@@ -274,7 +284,7 @@ new Workflow(scope: Construct, id: string, config: WorkflowProps)
 * **id** (<code>string</code>)  The name of this workflow.
 * **config** (<code>[WorkflowProps](#cdkactions-workflowprops)</code>)  *No description*
   * **name** (<code>string</code>)  Name of the workflow. 
-  * **on** (<code>[ScheduleEvent](#cdkactions-scheduleevent) &#124; [WorkflowRunEvent](#cdkactions-workflowrunevent) &#124; [EventMap](#cdkactions-eventmap) &#124; string &#124; Array<string></code>)  When to run this workflow. 
+  * **on** (<code>[ScheduleEvent](#cdkactions-scheduleevent) &#124; [WorkflowRunEvent](#cdkactions-workflowrunevent) &#124; [WorkflowDispatchEvent](#cdkactions-workflowdispatchevent) &#124; [EventMap](#cdkactions-eventmap) &#124; string &#124; Array<string></code>)  When to run this workflow. 
   * **defaults** (<code>[DefaultsProps](#cdkactions-defaultsprops)</code>)  A map of default settings to apply to all steps in this job. __*Optional*__
   * **env** (<code>[StringMap](#cdkactions-stringmap)</code>)  A map of environment variables to provide to the job. __*Optional*__
 
@@ -734,6 +744,48 @@ Name | Type | Description
 
 
 
+## struct WorkflowDispatchEvent  <a id="cdkactions-workflowdispatchevent"></a>
+
+
+Configuration for the WorkflowDispatch event.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**workflowDispatch** | <code>[WorkflowDispatchEventProps](#cdkactions-workflowdispatcheventprops)</code> | <span></span>
+
+
+
+## struct WorkflowDispatchEventInputProps  <a id="cdkactions-workflowdispatcheventinputprops"></a>
+
+
+Configuration for a manually dispatched workflow input.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**required** | <code>boolean</code> | Whether the input is required.
+**type** | <code>[WorkflowDispatchInputType](#cdkactions-workflowdispatchinputtype)</code> | The type that identifies this input.
+**default**? | <code>string &#124; boolean</code> | The default value for the input if not supplied.<br/>__*Optional*__
+**description**? | <code>string</code> | A description for this particular input.<br/>__*Optional*__
+
+
+
+## struct WorkflowDispatchEventProps  <a id="cdkactions-workflowdispatcheventprops"></a>
+
+
+Configuration for the WorkflowDispatch event properties.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**inputs**? | <code>Map<string, [WorkflowDispatchEventInputProps](#cdkactions-workflowdispatcheventinputprops)></code> | __*Optional*__
+
+
+
 ## struct WorkflowProps  <a id="cdkactions-workflowprops"></a>
 
 
@@ -744,7 +796,7 @@ Configuration for a single GitHub Action workflow.
 Name | Type | Description 
 -----|------|-------------
 **name** | <code>string</code> | Name of the workflow.
-**on** | <code>[ScheduleEvent](#cdkactions-scheduleevent) &#124; [WorkflowRunEvent](#cdkactions-workflowrunevent) &#124; [EventMap](#cdkactions-eventmap) &#124; string &#124; Array<string></code> | When to run this workflow.
+**on** | <code>[ScheduleEvent](#cdkactions-scheduleevent) &#124; [WorkflowRunEvent](#cdkactions-workflowrunevent) &#124; [WorkflowDispatchEvent](#cdkactions-workflowdispatchevent) &#124; [EventMap](#cdkactions-eventmap) &#124; string &#124; Array<string></code> | When to run this workflow.
 **defaults**? | <code>[DefaultsProps](#cdkactions-defaultsprops)</code> | A map of default settings to apply to all steps in this job.<br/>__*Optional*__
 **env**? | <code>[StringMap](#cdkactions-stringmap)</code> | A map of environment variables to provide to the job.<br/>__*Optional*__
 
@@ -764,5 +816,17 @@ Name | Type | Description
 **branchesIgnore**? | <code>Array<string></code> | Branches to ignore when triggering this workflow.<br/>__*Optional*__
 **types**? | <code>Array<string></code> | Supported types.<br/>__*Optional*__
 
+
+
+## enum WorkflowDispatchInputType  <a id="cdkactions-workflowdispatchinputtype"></a>
+
+Workflow dispatch input types.
+
+Name | Description
+-----|-----
+**CHOICE** |
+**BOOLEAN** |
+**ENVIRONMENT** |
+**STRING** |
 
 

--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -40,7 +40,24 @@ export interface IssuesTypes {
   /**
    * Supported types.
    */
-  readonly types: Array<'opened' | 'edited' | 'deleted' | 'transferred' | 'pinned' | 'unpinned' | 'closed' | 'reopened' | 'assigned' | 'unassigned' | 'labeled' | 'unlabeled' | 'locked' | 'unlocked' | 'milestoned' | 'demilestoned'>;
+  readonly types: Array<
+    | 'opened'
+    | 'edited'
+    | 'deleted'
+    | 'transferred'
+    | 'pinned'
+    | 'unpinned'
+    | 'closed'
+    | 'reopened'
+    | 'assigned'
+    | 'unassigned'
+    | 'labeled'
+    | 'unlabeled'
+    | 'locked'
+    | 'unlocked'
+    | 'milestoned'
+    | 'demilestoned'
+  >;
 }
 
 /**
@@ -100,7 +117,22 @@ export interface PullRequestTypes extends PushTypes {
   /**
    * Supported types.
    */
-  readonly types?: Array<'assigned' | 'unassigned' | 'labeled' | 'unlabeled' | 'opened' | 'edited' | 'closed' | 'reopened' | 'synchronize' | 'ready_for_review' | 'locked' | 'unlocked' | 'review_requested' | 'review_request_removed'>;
+  readonly types?: Array<
+    | 'assigned'
+    | 'unassigned'
+    | 'labeled'
+    | 'unlabeled'
+    | 'opened'
+    | 'edited'
+    | 'closed'
+    | 'reopened'
+    | 'synchronize'
+    | 'ready_for_review'
+    | 'locked'
+    | 'unlocked'
+    | 'review_requested'
+    | 'review_request_removed'
+  >;
 }
 
 /**
@@ -130,7 +162,22 @@ export interface PullRequestTargetTypes {
   /**
    * Supported types.
    */
-  readonly types: Array<'assigned' | 'unassigned' | 'labeled' | 'unlabeled' | 'opened' | 'edited' | 'closed' | 'reopened' | 'synchronize' | 'ready_for_review' | 'locked' | 'unlocked' | 'review_requested' | 'review_request_removed'>;
+  readonly types: Array<
+    | 'assigned'
+    | 'unassigned'
+    | 'labeled'
+    | 'unlabeled'
+    | 'opened'
+    | 'edited'
+    | 'closed'
+    | 'reopened'
+    | 'synchronize'
+    | 'ready_for_review'
+    | 'locked'
+    | 'unlocked'
+    | 'review_requested'
+    | 'review_request_removed'
+  >;
 }
 
 /**
@@ -205,7 +252,7 @@ export interface ScheduleEvent {
   /**
    * A cron schedule to run the workflow on.
    */
-  readonly schedule: [{ 'cron': string }];
+  readonly schedule: [{ cron: string }];
 }
 
 /**
@@ -234,9 +281,68 @@ export interface WorkflowRunEvent {
 }
 
 /**
+ * Workflow dispatch input types.
+ */
+export enum WorkflowDispatchInputType {
+  CHOICE = 'choice',
+  BOOLEAN = 'boolean',
+  ENVIRONMENT = 'environment',
+  STRING = 'string',
+}
+
+/**
+ * Configuration for a manually dispatched workflow input
+ */
+export interface WorkflowDispatchEventInputProps {
+  /**
+   * The default value for the input if not supplied.
+   */
+  readonly default?: string | boolean;
+
+  /**
+   * A description for this particular input.
+   */
+  readonly description?: string;
+
+  /**
+   * Whether the input is required.
+   */
+  readonly required: boolean;
+
+  /**
+   * The type that identifies this input.
+   */
+  readonly type: WorkflowDispatchInputType;
+}
+
+/**
+ * Configuration for the WorkflowDispatch event properties.
+ */
+export interface WorkflowDispatchEventProps {
+  readonly inputs?: Record<string, WorkflowDispatchEventInputProps>;
+}
+
+/**
+ * Configuration for the WorkflowDispatch event.
+ */
+export interface WorkflowDispatchEvent {
+  readonly workflowDispatch: WorkflowDispatchEventProps;
+}
+
+/**
  * Events without additional subtypes.
  */
-export type EventStrings = 'workflowDispatch' | 'repositoryDispatch' | 'create' | 'delete' | 'deployment' | 'deploymentStatus' | 'fork' | 'gollum' | 'pageBuild' | 'public' | 'status';
+export type EventStrings =
+  | 'repositoryDispatch'
+  | 'create'
+  | 'delete'
+  | 'deployment'
+  | 'deploymentStatus'
+  | 'fork'
+  | 'gollum'
+  | 'pageBuild'
+  | 'public'
+  | 'status';
 
 /**
  * Events with additional subtypes.
@@ -345,7 +451,7 @@ export interface WorkflowProps {
   /**
    * When to run this workflow.
    */
-  readonly on: Events | Array<Events> | EventMap | ScheduleEvent | WorkflowRunEvent;
+  readonly on: Events | Array<Events> | EventMap | ScheduleEvent | WorkflowRunEvent | WorkflowDispatchEvent;
 
   /**
    * A map of environment variables to provide to the job.
@@ -420,4 +526,3 @@ export class Workflow extends Construct {
     return ghaction;
   }
 }
-

--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -41,22 +41,22 @@ export interface IssuesTypes {
    * Supported types.
    */
   readonly types: Array<
-    | 'opened'
-    | 'edited'
-    | 'deleted'
-    | 'transferred'
-    | 'pinned'
-    | 'unpinned'
-    | 'closed'
-    | 'reopened'
-    | 'assigned'
-    | 'unassigned'
-    | 'labeled'
-    | 'unlabeled'
-    | 'locked'
-    | 'unlocked'
-    | 'milestoned'
-    | 'demilestoned'
+  | 'opened'
+  | 'edited'
+  | 'deleted'
+  | 'transferred'
+  | 'pinned'
+  | 'unpinned'
+  | 'closed'
+  | 'reopened'
+  | 'assigned'
+  | 'unassigned'
+  | 'labeled'
+  | 'unlabeled'
+  | 'locked'
+  | 'unlocked'
+  | 'milestoned'
+  | 'demilestoned'
   >;
 }
 
@@ -118,20 +118,20 @@ export interface PullRequestTypes extends PushTypes {
    * Supported types.
    */
   readonly types?: Array<
-    | 'assigned'
-    | 'unassigned'
-    | 'labeled'
-    | 'unlabeled'
-    | 'opened'
-    | 'edited'
-    | 'closed'
-    | 'reopened'
-    | 'synchronize'
-    | 'ready_for_review'
-    | 'locked'
-    | 'unlocked'
-    | 'review_requested'
-    | 'review_request_removed'
+  | 'assigned'
+  | 'unassigned'
+  | 'labeled'
+  | 'unlabeled'
+  | 'opened'
+  | 'edited'
+  | 'closed'
+  | 'reopened'
+  | 'synchronize'
+  | 'ready_for_review'
+  | 'locked'
+  | 'unlocked'
+  | 'review_requested'
+  | 'review_request_removed'
   >;
 }
 
@@ -163,20 +163,20 @@ export interface PullRequestTargetTypes {
    * Supported types.
    */
   readonly types: Array<
-    | 'assigned'
-    | 'unassigned'
-    | 'labeled'
-    | 'unlabeled'
-    | 'opened'
-    | 'edited'
-    | 'closed'
-    | 'reopened'
-    | 'synchronize'
-    | 'ready_for_review'
-    | 'locked'
-    | 'unlocked'
-    | 'review_requested'
-    | 'review_request_removed'
+  | 'assigned'
+  | 'unassigned'
+  | 'labeled'
+  | 'unlabeled'
+  | 'opened'
+  | 'edited'
+  | 'closed'
+  | 'reopened'
+  | 'synchronize'
+  | 'ready_for_review'
+  | 'locked'
+  | 'unlocked'
+  | 'review_requested'
+  | 'review_request_removed'
   >;
 }
 

--- a/packages/cdkactions/test/__snapshots__/workflow.test.ts.snap
+++ b/packages/cdkactions/test/__snapshots__/workflow.test.ts.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`manual workflow dispatch 1`] = `
+Object {
+  "jobs": Object {},
+  "name": "Test",
+  "on": Object {
+    "workflowDispatch": Object {
+      "inputs": Object {
+        "one": Object {
+          "default": "foo",
+          "description": "input one",
+          "required": false,
+          "type": "string",
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`toGHAction 1`] = `
 Object {
   "defaults": Object {

--- a/packages/cdkactions/test/workflow.test.ts
+++ b/packages/cdkactions/test/workflow.test.ts
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { Job } from '../src';
+import { Job, WorkflowDispatchInputType } from '../src';
 import { TestingWorkflow } from './utils';
 
 test('toGHAction', () => {
@@ -41,14 +41,14 @@ test('2 jobs with same key -> error', () => {
     runsOn: 'ubuntu-latest',
     steps: [],
   });
-  expect(() =>
-    new Job(workflow, 'job', {
-      runsOn: 'ubuntu-latest',
-      steps: [],
-    }),
+  expect(
+    () =>
+      new Job(workflow, 'job', {
+        runsOn: 'ubuntu-latest',
+        steps: [],
+      }),
   ).toThrowError("There is already a Construct with name 'job' in Workflow [test]");
-},
-);
+});
 
 test('jobs kept in insertion order', () => {
   const workflow = TestingWorkflow();
@@ -70,11 +70,29 @@ test('jobs kept in insertion order', () => {
   const jobs = Object.keys(workflow.toGHAction().jobs);
   const expected = [job_one, job_two, job_three];
   expect(jobs).toEqual(expected);
-},
-);
+});
 
 test('non-job children are ignored', () => {
   const workflow = TestingWorkflow();
   new Construct(workflow, 'not_job');
   expect(workflow.toGHAction().jobs).toEqual({});
+});
+
+test('manual workflow dispatch', () => {
+  const workflow = TestingWorkflow({
+    name: 'Test',
+    on: {
+      workflowDispatch: {
+        inputs: {
+          one: {
+            default: 'foo',
+            description: 'input one',
+            required: false,
+            type: WorkflowDispatchInputType.STRING,
+          },
+        },
+      },
+    },
+  });
+  expect(workflow.toGHAction()).toMatchSnapshot();
 });


### PR DESCRIPTION
Workflow triggers are now extended with `workflowDispatch` and supported inputs.