### PR TITLE
feat(cdkactions): Add JobStepBuilder for compile-time step ID uniqueness

### DIFF
--- a/packages/cdkactions/src/index.ts
+++ b/packages/cdkactions/src/index.ts
@@ -1,6 +1,7 @@
 export * from './app.js';
 export * from './composite-action.js';
 export * from './job.js';
+export * from './job-builder.js';
 export * from './library.js';
 export * from './stack.js';
 export * from './types.js';

--- a/packages/cdkactions/src/job-builder.ts
+++ b/packages/cdkactions/src/job-builder.ts
@@ -1,0 +1,68 @@
+import type { StepsProps } from './job.js';
+
+/**
+ * A step with a known `id` string literal, used by the builder
+ * to track which IDs have been claimed.
+ */
+type IdentifiedStep<Id extends string> = StepsProps & { readonly id: Id };
+
+/**
+ * A step that is guaranteed *not* to carry an `id`, so it can
+ * never collide with anything.
+ */
+type AnonymousStep = StepsProps & { readonly id?: undefined };
+
+/**
+ * Accepts either an anonymous step or an identified step whose
+ * `id` has not yet been used.
+ */
+type NewStep<UsedIds extends string> =
+  | AnonymousStep
+  | (IdentifiedStep<string> & { readonly id: string extends infer Id extends string
+      ? Id extends UsedIds ? never : Id
+      : never });
+
+/**
+ * Fluent builder that assembles an ordered list of steps while
+ * rejecting duplicate `id` values at compile time.
+ *
+ * @typeParam UsedIds - Union of step `id` literals added so far.
+ *
+ * @example
+ * ```ts
+ * const steps = new JobStepBuilder()
+ *   .step({ run: 'echo hello' })
+ *   .step(myAction.asStep(scope, { id: 'fetch' }))
+ *   .step(other.asStep(scope, { id: 'fetch' }))  // TS error — duplicate id
+ *   .build();
+ * ```
+ */
+export class JobStepBuilder<UsedIds extends string = never> {
+  private readonly steps: StepsProps[];
+
+  /** @internal */
+  constructor(steps: StepsProps[] = []) {
+    this.steps = steps;
+  }
+
+  /**
+   * Append a step without an `id` (never conflicts).
+   */
+  step(step: AnonymousStep): JobStepBuilder<UsedIds>;
+  /**
+   * Append a step whose `id` must not already be present in the builder.
+   */
+  step<Id extends string>(
+    step: IdentifiedStep<Id extends UsedIds ? never : Id>,
+  ): JobStepBuilder<UsedIds | Id>;
+  step(step: StepsProps): JobStepBuilder<any> {
+    return new JobStepBuilder([...this.steps, step]);
+  }
+
+  /**
+   * Return the accumulated steps array, ready to pass to `JobProps.steps`.
+   */
+  build(): StepsProps[] {
+    return this.steps;
+  }
+}

--- a/packages/cdkactions/src/job-builder.ts
+++ b/packages/cdkactions/src/job-builder.ts
@@ -39,10 +39,12 @@ type NewStep<UsedIds extends string> =
  */
 export class JobStepBuilder<UsedIds extends string = never> {
   private readonly steps: StepsProps[];
+  private readonly usedIds: Set<string>;
 
   /** @internal */
-  constructor(steps: StepsProps[] = []) {
+  constructor(steps: StepsProps[] = [], usedIds: Set<string> = new Set()) {
     this.steps = steps;
+    this.usedIds = usedIds;
   }
 
   /**
@@ -56,7 +58,15 @@ export class JobStepBuilder<UsedIds extends string = never> {
     step: IdentifiedStep<Id extends UsedIds ? never : Id>,
   ): JobStepBuilder<UsedIds | Id>;
   step(step: StepsProps): JobStepBuilder<any> {
-    return new JobStepBuilder([...this.steps, step]);
+    if (step.id !== undefined) {
+      if (this.usedIds.has(step.id)) {
+        throw new Error(`Duplicate step id "${step.id}"`);
+      }
+      const nextIds = new Set(this.usedIds);
+      nextIds.add(step.id);
+      return new JobStepBuilder([...this.steps, step], nextIds);
+    }
+    return new JobStepBuilder([...this.steps, step], this.usedIds);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds `JobStepBuilder`, a fluent builder that accumulates step ID string literals in a type parameter and rejects duplicates at compile time
- Anonymous steps (no `id`) are always accepted; identified steps error if the `id` has already been claimed
- Returns a `StepsProps[]` via `.build()`, ready to pass to `JobProps.steps`

## Test plan
- [ ] Verify that chaining `.step()` with duplicate `id` literals produces a TypeScript error
- [ ] Verify that anonymous steps and unique IDs compile without errors
- [ ] Run `yarn build` to confirm no type errors