### PR TITLE
refactor(cdkactions): Make output() non-enumerable

### DIFF
--- a/packages/cdkactions/src/composite-action.ts
+++ b/packages/cdkactions/src/composite-action.ts
@@ -140,15 +140,16 @@ export class CompositeAction<const TInputs extends Record<string, CompositeActio
     const options = args[0];
     const id = options?.id;
 
-    const step: CompositeActionStepRef<TOutputs> = {
+    const step: StepsProps = {
       ...options,
       uses: this.usesPath,
-      output(key) {
-        return `\${{ steps.${id}.outputs.${key} }}`;
-      },
     };
+    Object.defineProperty(step, 'output', {
+      value: (key: string) => `\${{ steps.${id}.outputs.${key} }}`,
+      enumerable: false,
+    });
 
-    return step;
+    return step as CompositeActionStepRef<TOutputs>;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Attaches `output()` via `Object.defineProperty` with `enumerable: false` instead of as an inline method on the object literal
- Prevents the method from leaking into YAML serialization while keeping it accessible on the step reference

## Test plan
- [ ] Verify `step.output('key')` still returns the correct expression
- [ ] Verify `output` does not appear when the step object is serialized (e.g. `JSON.stringify` or YAML dump)
- [ ] Run `yarn build` to confirm no type errors