### PR TITLE
feat(cdkactions): Forward composite action name to asStep

### DIFF
--- a/packages/cdkactions/src/composite-action.ts
+++ b/packages/cdkactions/src/composite-action.ts
@@ -141,6 +141,7 @@ export class CompositeAction<const TInputs extends Record<string, CompositeActio
     const id = options?.id;
 
     const step: StepsProps = {
+      name: this.config.name,
       ...options,
       uses: this.usesPath,
     };


### PR DESCRIPTION
## Summary
- Defaults the step `name` to the composite action's `name` property when calling `asStep()`, so workflow steps show a meaningful label automatically.
- Callers can still override the name by passing an explicit `name` in the options (spread comes after the default).

## Test plan
- [ ] Verify that `asStep()` without a `name` option produces a step with the action's name
- [ ] Verify that `asStep()` with an explicit `name` option uses the caller-provided name
- [ ] Confirm build passes