### PR TITLE
feat(cdkactions): S02 - Nominal types: RunnerLabel, Shell, JobResult, StepConclusion

### DIFF
--- a/packages/cdkactions/src/index.ts
+++ b/packages/cdkactions/src/index.ts
@@ -3,6 +3,7 @@ export * from './composite-action.js';
 export * from './expressions.js';
 export * from './job.js';
 export * from './library.js';
+export * from './nominal.js';
 export * from './stack.js';
 export * from './types.js';
 export * from './workflow.js';

--- a/packages/cdkactions/src/nominal.ts
+++ b/packages/cdkactions/src/nominal.ts
@@ -1,0 +1,117 @@
+/**
+ * Nominal (branded) types for GitHub Actions values.
+ *
+ * These prevent accidental use of bare strings where a specific label,
+ * shell, or result value is expected. Each type uses a unique symbol brand
+ * so that plain strings are not assignable without going through the
+ * constructors or predefined constants.
+ */
+
+// ─── RunnerLabel ────────────────────────────────────────────────────────────────
+
+declare const RunnerLabelBrand: unique symbol;
+
+/**
+ * A branded string representing a GitHub Actions runner label.
+ * Bare strings are not assignable — use the predefined constants
+ * or `RunnerLabel.custom()`.
+ */
+export type RunnerLabel = string & { readonly [RunnerLabelBrand]: true };
+
+function runnerLabel(value: string): RunnerLabel {
+  return value as RunnerLabel;
+}
+
+/** Predefined GitHub-hosted runner labels and a `custom()` escape hatch. */
+export namespace RunnerLabel {
+  export const UBUNTU_LATEST = runnerLabel('ubuntu-latest');
+  export const UBUNTU_22_04 = runnerLabel('ubuntu-22.04');
+  export const UBUNTU_24_04 = runnerLabel('ubuntu-24.04');
+  export const WINDOWS_LATEST = runnerLabel('windows-latest');
+  export const WINDOWS_2022 = runnerLabel('windows-2022');
+  export const WINDOWS_2025 = runnerLabel('windows-2025');
+  export const MACOS_LATEST = runnerLabel('macos-latest');
+  export const MACOS_13 = runnerLabel('macos-13');
+  export const MACOS_14 = runnerLabel('macos-14');
+  export const MACOS_15 = runnerLabel('macos-15');
+  export const SELF_HOSTED = runnerLabel('self-hosted');
+
+  /** Create a RunnerLabel for a custom or self-hosted runner label. */
+  export function custom(label: string): RunnerLabel {
+    return runnerLabel(label);
+  }
+}
+
+// ─── Shell ──────────────────────────────────────────────────────────────────────
+
+declare const ShellBrand: unique symbol;
+
+/**
+ * A branded string representing a shell type for step execution.
+ * Bare strings are not assignable — use the predefined constants
+ * or `Shell.custom()`.
+ */
+export type Shell = string & { readonly [ShellBrand]: true };
+
+function shell(value: string): Shell {
+  return value as Shell;
+}
+
+/** Predefined shell values and a `custom()` escape hatch. */
+export namespace Shell {
+  export const BASH = shell('bash');
+  export const PWSH = shell('pwsh');
+  export const PYTHON = shell('python');
+  export const SH = shell('sh');
+  export const CMD = shell('cmd');
+  export const POWERSHELL = shell('powershell');
+
+  /** Create a Shell for a custom shell command. */
+  export function custom(value: string): Shell {
+    return shell(value);
+  }
+}
+
+// ─── JobResult ──────────────────────────────────────────────────────────────────
+
+declare const JobResultBrand: unique symbol;
+
+/**
+ * A branded string representing a job result status.
+ * Used in `needs.<job>.result` comparisons.
+ */
+export type JobResult = string & { readonly [JobResultBrand]: true };
+
+function jobResult(value: string): JobResult {
+  return value as JobResult;
+}
+
+/** Predefined job result values. */
+export namespace JobResult {
+  export const SUCCESS = jobResult('success');
+  export const FAILURE = jobResult('failure');
+  export const CANCELLED = jobResult('cancelled');
+  export const SKIPPED = jobResult('skipped');
+}
+
+// ─── StepConclusion ─────────────────────────────────────────────────────────────
+
+declare const StepConclusionBrand: unique symbol;
+
+/**
+ * A branded string representing a step conclusion status.
+ * Used in `steps.<step>.conclusion` comparisons.
+ */
+export type StepConclusion = string & { readonly [StepConclusionBrand]: true };
+
+function stepConclusion(value: string): StepConclusion {
+  return value as StepConclusion;
+}
+
+/** Predefined step conclusion values. */
+export namespace StepConclusion {
+  export const SUCCESS = stepConclusion('success');
+  export const FAILURE = stepConclusion('failure');
+  export const CANCELLED = stepConclusion('cancelled');
+  export const SKIPPED = stepConclusion('skipped');
+}

--- a/packages/cdkactions/src/nominal.ts
+++ b/packages/cdkactions/src/nominal.ts
@@ -7,8 +7,6 @@
  * constructors or predefined constants.
  */
 
-// ─── RunnerLabel ────────────────────────────────────────────────────────────────
-
 declare const RunnerLabelBrand: unique symbol;
 
 /**
@@ -42,8 +40,6 @@ export namespace RunnerLabel {
   }
 }
 
-// ─── Shell ──────────────────────────────────────────────────────────────────────
-
 declare const ShellBrand: unique symbol;
 
 /**
@@ -72,8 +68,6 @@ export namespace Shell {
   }
 }
 
-// ─── JobResult ──────────────────────────────────────────────────────────────────
-
 declare const JobResultBrand: unique symbol;
 
 /**
@@ -93,8 +87,6 @@ export namespace JobResult {
   export const CANCELLED = jobResult('cancelled');
   export const SKIPPED = jobResult('skipped');
 }
-
-// ─── StepConclusion ─────────────────────────────────────────────────────────────
 
 declare const StepConclusionBrand: unique symbol;
 

--- a/packages/cdkactions/test/nominal.test.ts
+++ b/packages/cdkactions/test/nominal.test.ts
@@ -1,0 +1,96 @@
+import {
+  RunnerLabel,
+  Shell,
+  JobResult,
+  StepConclusion,
+} from '../src';
+
+// ─── RunnerLabel ────────────────────────────────────────────────────────────────
+
+test('RunnerLabel predefined constants have correct string values', () => {
+  expect(String(RunnerLabel.UBUNTU_LATEST)).toBe('ubuntu-latest');
+  expect(String(RunnerLabel.UBUNTU_22_04)).toBe('ubuntu-22.04');
+  expect(String(RunnerLabel.UBUNTU_24_04)).toBe('ubuntu-24.04');
+  expect(String(RunnerLabel.WINDOWS_LATEST)).toBe('windows-latest');
+  expect(String(RunnerLabel.WINDOWS_2022)).toBe('windows-2022');
+  expect(String(RunnerLabel.WINDOWS_2025)).toBe('windows-2025');
+  expect(String(RunnerLabel.MACOS_LATEST)).toBe('macos-latest');
+  expect(String(RunnerLabel.MACOS_13)).toBe('macos-13');
+  expect(String(RunnerLabel.MACOS_14)).toBe('macos-14');
+  expect(String(RunnerLabel.MACOS_15)).toBe('macos-15');
+  expect(String(RunnerLabel.SELF_HOSTED)).toBe('self-hosted');
+});
+
+test('RunnerLabel.custom() creates a RunnerLabel from arbitrary string', () => {
+  const custom = RunnerLabel.custom('my-custom-runner');
+  expect(String(custom)).toBe('my-custom-runner');
+});
+
+// ─── Shell ──────────────────────────────────────────────────────────────────────
+
+test('Shell predefined constants have correct string values', () => {
+  expect(String(Shell.BASH)).toBe('bash');
+  expect(String(Shell.PWSH)).toBe('pwsh');
+  expect(String(Shell.PYTHON)).toBe('python');
+  expect(String(Shell.SH)).toBe('sh');
+  expect(String(Shell.CMD)).toBe('cmd');
+  expect(String(Shell.POWERSHELL)).toBe('powershell');
+});
+
+test('Shell.custom() creates a Shell from arbitrary string', () => {
+  const custom = Shell.custom('perl {0}');
+  expect(String(custom)).toBe('perl {0}');
+});
+
+// ─── JobResult ──────────────────────────────────────────────────────────────────
+
+test('JobResult constants have correct string values', () => {
+  expect(String(JobResult.SUCCESS)).toBe('success');
+  expect(String(JobResult.FAILURE)).toBe('failure');
+  expect(String(JobResult.CANCELLED)).toBe('cancelled');
+  expect(String(JobResult.SKIPPED)).toBe('skipped');
+});
+
+// ─── StepConclusion ─────────────────────────────────────────────────────────────
+
+test('StepConclusion constants have correct string values', () => {
+  expect(String(StepConclusion.SUCCESS)).toBe('success');
+  expect(String(StepConclusion.FAILURE)).toBe('failure');
+  expect(String(StepConclusion.CANCELLED)).toBe('cancelled');
+  expect(String(StepConclusion.SKIPPED)).toBe('skipped');
+});
+
+// ─── Type-Level Tests ───────────────────────────────────────────────────────────
+// These verify that bare strings are NOT assignable to nominal types.
+
+// @ts-expect-error — bare string is not assignable to RunnerLabel
+const _badRunner: RunnerLabel = 'ubuntu-latest';
+
+// @ts-expect-error — bare string is not assignable to Shell
+const _badShell: Shell = 'bash';
+
+// @ts-expect-error — bare string is not assignable to JobResult
+const _badResult: JobResult = 'success';
+
+// @ts-expect-error — bare string is not assignable to StepConclusion
+const _badConclusion: StepConclusion = 'success';
+
+// Valid assignments through constructors
+const _goodRunner: RunnerLabel = RunnerLabel.UBUNTU_LATEST;
+const _goodCustomRunner: RunnerLabel = RunnerLabel.custom('my-runner');
+const _goodShell: Shell = Shell.BASH;
+const _goodCustomShell: Shell = Shell.custom('zsh');
+const _goodResult: JobResult = JobResult.SUCCESS;
+const _goodConclusion: StepConclusion = StepConclusion.SUCCESS;
+
+// Suppress unused variable warnings
+void _badRunner;
+void _badShell;
+void _badResult;
+void _badConclusion;
+void _goodRunner;
+void _goodCustomRunner;
+void _goodShell;
+void _goodCustomShell;
+void _goodResult;
+void _goodConclusion;

--- a/packages/cdkactions/test/nominal.test.ts
+++ b/packages/cdkactions/test/nominal.test.ts
@@ -5,7 +5,6 @@ import {
   StepConclusion,
 } from '../src';
 
-// ─── RunnerLabel ────────────────────────────────────────────────────────────────
 
 test('RunnerLabel predefined constants have correct string values', () => {
   expect(String(RunnerLabel.UBUNTU_LATEST)).toBe('ubuntu-latest');
@@ -26,7 +25,6 @@ test('RunnerLabel.custom() creates a RunnerLabel from arbitrary string', () => {
   expect(String(custom)).toBe('my-custom-runner');
 });
 
-// ─── Shell ──────────────────────────────────────────────────────────────────────
 
 test('Shell predefined constants have correct string values', () => {
   expect(String(Shell.BASH)).toBe('bash');
@@ -42,7 +40,6 @@ test('Shell.custom() creates a Shell from arbitrary string', () => {
   expect(String(custom)).toBe('perl {0}');
 });
 
-// ─── JobResult ──────────────────────────────────────────────────────────────────
 
 test('JobResult constants have correct string values', () => {
   expect(String(JobResult.SUCCESS)).toBe('success');
@@ -51,7 +48,6 @@ test('JobResult constants have correct string values', () => {
   expect(String(JobResult.SKIPPED)).toBe('skipped');
 });
 
-// ─── StepConclusion ─────────────────────────────────────────────────────────────
 
 test('StepConclusion constants have correct string values', () => {
   expect(String(StepConclusion.SUCCESS)).toBe('success');
@@ -60,7 +56,6 @@ test('StepConclusion constants have correct string values', () => {
   expect(String(StepConclusion.SKIPPED)).toBe('skipped');
 });
 
-// ─── Type-Level Tests ───────────────────────────────────────────────────────────
 // These verify that bare strings are NOT assignable to nominal types.
 
 // @ts-expect-error — bare string is not assignable to RunnerLabel


### PR DESCRIPTION
## Motivation

GitHub Actions runner labels, shells, job results, and step conclusions are stringly-typed — any typo compiles fine and fails silently at runtime. Branded nominal types catch these errors at compile time while still serializing to plain strings in YAML output.

## Summary

- `RunnerLabel` branded type with all 11 GitHub-hosted runner constants (`UBUNTU_LATEST`, `WINDOWS_2025`, `MACOS_15`, etc.) and `custom()` escape hatch
- `Shell` branded type with 6 known shells (`BASH`, `PWSH`, `PYTHON`, `SH`, `CMD`, `POWERSHELL`) and `custom()` escape hatch
- `JobResult` branded type with `SUCCESS`, `FAILURE`, `CANCELLED`, `SKIPPED`
- `StepConclusion` branded type with `SUCCESS`, `FAILURE`, `CANCELLED`, `SKIPPED`
- All types exported from `src/index.ts`
- `TokenPermission` left as-is (already a union type)

## Test plan

- [x] Unit tests verify all predefined constant values
- [x] Unit tests verify `custom()` escape hatch for RunnerLabel and Shell
- [x] Type-level tests: `@ts-expect-error` confirms bare strings are rejected for all 4 nominal types
- [x] `yarn build` passes