### PR TITLE
feat(cdkactions): S03 - ActionRef<TInputs, TOutputs> and TypedUsesStep

### DIFF
--- a/packages/cdkactions/src/action-ref.ts
+++ b/packages/cdkactions/src/action-ref.ts
@@ -1,0 +1,186 @@
+/**
+ * Typed references to external GitHub Actions.
+ *
+ * ActionRef captures an action's input/output schema at the type level,
+ * enabling compile-time enforcement of required inputs, rejection of
+ * unknown inputs, and typed output accessors.
+ */
+
+import type { Expression } from './expressions.js';
+import { camelToKebab } from './utils.js';
+
+// ─── Action Schema Types ────────────────────────────────────────────────────────
+
+/**
+ * Describes a single action input — whether it's required and/or has a default.
+ */
+export interface ActionInput {
+  readonly required?: boolean;
+  readonly default?: string;
+}
+
+/**
+ * Map of input names to their schema.
+ */
+export type ActionInputs = Record<string, ActionInput>;
+
+/**
+ * Map of output names to their metadata.
+ */
+export type ActionOutputs = Record<string, { readonly description?: string }>;
+
+// ─── Input Key Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Keys of inputs that are required:
+ * - explicitly `{ required: true }`, OR
+ * - have no `default` and no `required: true` (bare `{}` means required)
+ */
+type RequiredInputKeys<T extends ActionInputs> = {
+  [K in keyof T & string]: T[K] extends { required: true } ? K
+    : T[K] extends { default: string } ? never
+    : K;
+}[keyof T & string];
+
+/**
+ * Keys of inputs that are optional (have a default value).
+ */
+type OptionalInputKeys<T extends ActionInputs> = {
+  [K in keyof T & string]: T[K] extends { required: true } ? never
+    : T[K] extends { default: string } ? K
+    : never;
+}[keyof T & string];
+
+/**
+ * The `with` object shape derived from the action's input schema.
+ * Required inputs are mandatory; inputs with defaults are optional.
+ */
+type ActionWith<T extends ActionInputs> = {
+  readonly [K in RequiredInputKeys<T>]: string | number | boolean;
+} & {
+  readonly [K in OptionalInputKeys<T>]?: string | number | boolean;
+};
+
+// ─── Call Options ───────────────────────────────────────────────────────────────
+
+/**
+ * Step-level properties that can be set when calling an action.
+ */
+export interface StepBase {
+  readonly name?: string;
+  readonly if?: string;
+  readonly env?: Record<string, string>;
+  readonly continueOnError?: boolean;
+  readonly timeoutMinutes?: number;
+}
+
+type ActionCallOptions<TInputs extends ActionInputs, TOutputs extends ActionOutputs> =
+  & ([RequiredInputKeys<TInputs>] extends [never]
+    ? { with?: ActionWith<TInputs> }
+    : { with: ActionWith<TInputs> })
+  & ([keyof TOutputs] extends [never]
+    ? { id?: string }
+    : { id: string });
+
+// ─── TypedUsesStep ──────────────────────────────────────────────────────────────
+
+/**
+ * A uses-step with typed output accessors.
+ * Extends the plain UsesStep shape so it can be used anywhere StepConfig is accepted.
+ */
+export interface TypedUsesStep<TOutputs extends ActionOutputs = ActionOutputs> {
+  readonly id?: string;
+  readonly name?: string;
+  readonly if?: string;
+  readonly uses: string;
+  readonly with?: Record<string, string | number | boolean>;
+  readonly env?: Record<string, string>;
+  readonly continueOnError?: boolean;
+  readonly timeoutMinutes?: number;
+
+  /**
+   * Reference an output of this step.
+   * Returns an Expression<string> of the form `steps.<id>.outputs.<key>`.
+   */
+  output<K extends keyof TOutputs & string>(key: K): Expression<string>;
+}
+
+// ─── ActionRef ──────────────────────────────────────────────────────────────────
+
+/**
+ * A typed reference to an external GitHub Action.
+ * TInputs captures the action's input schema; TOutputs captures its output schema.
+ */
+export class ActionRef<
+  const TInputs extends ActionInputs = ActionInputs,
+  const TOutputs extends ActionOutputs = ActionOutputs,
+> {
+  public readonly ref: string;
+
+  private constructor(ref: string) {
+    this.ref = ref;
+  }
+
+  /**
+   * Define a typed action reference.
+   *
+   * @example
+   * const checkoutV4 = ActionRef.fromReference<{
+   *   repository: { default: '${{ github.repository }}' };
+   *   ref: {};
+   *   token: { default: '${{ github.token }}' };
+   * }, {
+   *   ref: {};
+   *   commit: {};
+   * }>('actions/checkout@v4');
+   */
+  static fromReference<
+    TInputs extends ActionInputs = Record<never, never>,
+    TOutputs extends ActionOutputs = Record<never, never>,
+  >(ref: string): ActionRef<TInputs, TOutputs> {
+    return new ActionRef<TInputs, TOutputs>(ref);
+  }
+
+  /**
+   * Create a step that uses this action.
+   * Required inputs must be provided; inputs with defaults are optional.
+   * Unknown inputs are compile errors (via excess property checks).
+   *
+   * When TOutputs is non-empty, `id` is required so outputs can be referenced
+   * via `${{ steps.<id>.outputs.<key> }}`.
+   */
+  public call(
+    options: StepBase & ActionCallOptions<TInputs, TOutputs>,
+  ): TypedUsesStep<TOutputs> {
+    const { id, name, env, continueOnError, timeoutMinutes } = options as StepBase & { id?: string };
+    const ifProp = (options as StepBase)['if'];
+    const withProp = (options as { with?: Record<string, string | number | boolean> }).with;
+
+    // Convert camelCase input keys to kebab-case for GitHub Actions
+    const serializedWith = withProp
+      ? Object.fromEntries(
+          Object.entries(withProp).map(([k, v]) => [camelToKebab(k), v]),
+        )
+      : undefined;
+
+    const stepId = id;
+    const step: TypedUsesStep<TOutputs> = {
+      ...(stepId !== undefined && { id: stepId }),
+      ...(name !== undefined && { name }),
+      ...(ifProp !== undefined && { if: ifProp }),
+      uses: this.ref,
+      ...(serializedWith !== undefined && { with: serializedWith }),
+      ...(env !== undefined && { env }),
+      ...(continueOnError !== undefined && { continueOnError }),
+      ...(timeoutMinutes !== undefined && { timeoutMinutes }),
+      output<K extends keyof TOutputs & string>(key: K): Expression<string> {
+        if (!stepId) {
+          throw new Error('Cannot access outputs on a step without an id');
+        }
+        return `steps.${stepId}.outputs.${key}` as Expression<string>;
+      },
+    };
+
+    return step;
+  }
+}

--- a/packages/cdkactions/src/action-ref.ts
+++ b/packages/cdkactions/src/action-ref.ts
@@ -1,71 +1,33 @@
-/**
- * Typed references to external GitHub Actions.
- *
- * ActionRef captures an action's input/output schema at the type level,
- * enabling compile-time enforcement of required inputs, rejection of
- * unknown inputs, and typed output accessors.
- */
-
 import type { Expression } from './expressions.js';
 import { camelToKebab } from './utils.js';
 
-// ─── Action Schema Types ────────────────────────────────────────────────────────
-
-/**
- * Describes a single action input — whether it's required and/or has a default.
- */
 export interface ActionInput {
   readonly required?: boolean;
   readonly default?: string;
 }
 
-/**
- * Map of input names to their schema.
- */
 export type ActionInputs = Record<string, ActionInput>;
 
-/**
- * Map of output names to their metadata.
- */
 export type ActionOutputs = Record<string, { readonly description?: string }>;
 
-// ─── Input Key Helpers ──────────────────────────────────────────────────────────
-
-/**
- * Keys of inputs that are required:
- * - explicitly `{ required: true }`, OR
- * - have no `default` and no `required: true` (bare `{}` means required)
- */
 type RequiredInputKeys<T extends ActionInputs> = {
   [K in keyof T & string]: T[K] extends { required: true } ? K
     : T[K] extends { default: string } ? never
     : K;
 }[keyof T & string];
 
-/**
- * Keys of inputs that are optional (have a default value).
- */
 type OptionalInputKeys<T extends ActionInputs> = {
   [K in keyof T & string]: T[K] extends { required: true } ? never
     : T[K] extends { default: string } ? K
     : never;
 }[keyof T & string];
 
-/**
- * The `with` object shape derived from the action's input schema.
- * Required inputs are mandatory; inputs with defaults are optional.
- */
 type ActionWith<T extends ActionInputs> = {
   readonly [K in RequiredInputKeys<T>]: string | number | boolean;
 } & {
   readonly [K in OptionalInputKeys<T>]?: string | number | boolean;
 };
 
-// ─── Call Options ───────────────────────────────────────────────────────────────
-
-/**
- * Step-level properties that can be set when calling an action.
- */
 export interface StepBase {
   readonly name?: string;
   readonly if?: string;
@@ -82,12 +44,6 @@ type ActionCallOptions<TInputs extends ActionInputs, TOutputs extends ActionOutp
     ? { id?: string }
     : { id: string });
 
-// ─── TypedUsesStep ──────────────────────────────────────────────────────────────
-
-/**
- * A uses-step with typed output accessors.
- * Extends the plain UsesStep shape so it can be used anywhere StepConfig is accepted.
- */
 export interface TypedUsesStep<TOutputs extends ActionOutputs = ActionOutputs> {
   readonly id?: string;
   readonly name?: string;
@@ -98,19 +54,9 @@ export interface TypedUsesStep<TOutputs extends ActionOutputs = ActionOutputs> {
   readonly continueOnError?: boolean;
   readonly timeoutMinutes?: number;
 
-  /**
-   * Reference an output of this step.
-   * Returns an Expression<string> of the form `steps.<id>.outputs.<key>`.
-   */
   output<K extends keyof TOutputs & string>(key: K): Expression<string>;
 }
 
-// ─── ActionRef ──────────────────────────────────────────────────────────────────
-
-/**
- * A typed reference to an external GitHub Action.
- * TInputs captures the action's input schema; TOutputs captures its output schema.
- */
 export class ActionRef<
   const TInputs extends ActionInputs = ActionInputs,
   const TOutputs extends ActionOutputs = ActionOutputs,
@@ -121,19 +67,6 @@ export class ActionRef<
     this.ref = ref;
   }
 
-  /**
-   * Define a typed action reference.
-   *
-   * @example
-   * const checkoutV4 = ActionRef.fromReference<{
-   *   repository: { default: '${{ github.repository }}' };
-   *   ref: {};
-   *   token: { default: '${{ github.token }}' };
-   * }, {
-   *   ref: {};
-   *   commit: {};
-   * }>('actions/checkout@v4');
-   */
   static fromReference<
     TInputs extends ActionInputs = Record<never, never>,
     TOutputs extends ActionOutputs = Record<never, never>,
@@ -141,14 +74,6 @@ export class ActionRef<
     return new ActionRef<TInputs, TOutputs>(ref);
   }
 
-  /**
-   * Create a step that uses this action.
-   * Required inputs must be provided; inputs with defaults are optional.
-   * Unknown inputs are compile errors (via excess property checks).
-   *
-   * When TOutputs is non-empty, `id` is required so outputs can be referenced
-   * via `${{ steps.<id>.outputs.<key> }}`.
-   */
   public call(
     options: StepBase & ActionCallOptions<TInputs, TOutputs>,
   ): TypedUsesStep<TOutputs> {

--- a/packages/cdkactions/src/index.ts
+++ b/packages/cdkactions/src/index.ts
@@ -1,3 +1,4 @@
+export * from './action-ref.js';
 export * from './app.js';
 export * from './composite-action.js';
 export * from './expressions.js';

--- a/packages/cdkactions/src/utils.ts
+++ b/packages/cdkactions/src/utils.ts
@@ -27,3 +27,5 @@ export const renameKeys = (obj: any, newKeys: StringMap) => {
 };
 
 export const camelToSnake = (str: string) => str.replace(/[A-Z]/g, (group) => `_${group.toLowerCase()}`);
+
+export const camelToKebab = (str: string) => str.replace(/[A-Z]/g, (group) => `-${group.toLowerCase()}`);

--- a/packages/cdkactions/test/action-ref.test.ts
+++ b/packages/cdkactions/test/action-ref.test.ts
@@ -1,0 +1,234 @@
+import { ActionRef, type TypedUsesStep, type Expression } from '../src/index.js';
+
+// ─── Test Fixtures ──────────────────────────────────────────────────────────────
+
+// Action with all-optional inputs (all have defaults) and outputs
+const allOptionalAction = ActionRef.fromReference<
+  {
+    repository: { default: '${{ github.repository }}' };
+    token: { default: '${{ github.token }}' };
+    fetchDepth: { default: '1' };
+  },
+  {
+    ref: {};
+    commit: {};
+  }
+>('actions/all-optional@v1');
+
+// Action with both required and optional inputs, and outputs
+const uploadArtifactV4 = ActionRef.fromReference<
+  {
+    name: { required: true };
+    path: { required: true };
+    ifNoFilesFound: { default: 'warn' };
+    compressionLevel: { default: '6' };
+  },
+  {
+    artifactId: {};
+    artifactUrl: {};
+  }
+>('actions/upload-artifact@v4');
+
+// Action with required inputs (bare {} = required) and outputs
+const setupAction = ActionRef.fromReference<
+  {
+    nodeVersion: {};
+    cache: { default: '' };
+  },
+  {
+    cacheHit: {};
+  }
+>('actions/setup-node@v4');
+
+// Action with no inputs and no outputs
+const emptyAction = ActionRef.fromReference('actions/empty@v1');
+
+// Action with no outputs (id should be optional)
+const noOutputAction = ActionRef.fromReference<
+  { inputA: { required: true } },
+  Record<never, never>
+>('actions/no-output@v1');
+
+// ─── Runtime Tests ──────────────────────────────────────────────────────────────
+
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (e: any) {
+    console.error(`  ✗ ${name}: ${e.message}`);
+    process.exitCode = 1;
+  }
+}
+
+function expect<T>(actual: T) {
+  return {
+    toBe(expected: T) {
+      if (actual !== expected) {
+        throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+      }
+    },
+    toEqual(expected: T) {
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+      }
+    },
+  };
+}
+
+console.log('ActionRef');
+
+// ─── fromReference ──────────────────────────────────────────────────────────────
+
+test('fromReference stores the action ref string', () => {
+  expect(allOptionalAction.ref).toBe('actions/all-optional@v1');
+});
+
+test('fromReference with no type params', () => {
+  const action = ActionRef.fromReference('my/action@v1');
+  expect(action.ref).toBe('my/action@v1');
+});
+
+// ─── call() — basic step shape ──────────────────────────────────────────────────
+
+test('call() produces a step with uses set to the ref', () => {
+  const step = allOptionalAction.call({ id: 'co' });
+  expect(step.uses).toBe('actions/all-optional@v1');
+});
+
+test('call() sets id on the step', () => {
+  const step = allOptionalAction.call({ id: 'co' });
+  expect(step.id).toBe('co');
+});
+
+test('call() sets name when provided', () => {
+  const step = allOptionalAction.call({ id: 'co', name: 'Checkout code' });
+  expect(step.name).toBe('Checkout code');
+});
+
+test('call() sets if when provided', () => {
+  const step = allOptionalAction.call({ id: 'co', if: 'github.ref == refs/heads/main' });
+  expect(step.if).toBe('github.ref == refs/heads/main');
+});
+
+test('call() sets env when provided', () => {
+  const step = allOptionalAction.call({ id: 'co', env: { NODE_ENV: 'production' } });
+  expect(step.env).toEqual({ NODE_ENV: 'production' });
+});
+
+test('call() sets continueOnError when provided', () => {
+  const step = allOptionalAction.call({ id: 'co', continueOnError: true });
+  expect(step.continueOnError).toBe(true);
+});
+
+test('call() sets timeoutMinutes when provided', () => {
+  const step = allOptionalAction.call({ id: 'co', timeoutMinutes: 10 });
+  expect(step.timeoutMinutes).toBe(10);
+});
+
+// ─── call() — with inputs ───────────────────────────────────────────────────────
+
+test('call() passes optional inputs in with', () => {
+  const step = allOptionalAction.call({ id: 'co', with: { fetchDepth: 0 } });
+  // camelCase keys are converted to kebab-case
+  expect(step.with).toEqual({ 'fetch-depth': 0 });
+});
+
+test('call() with required inputs', () => {
+  const step = uploadArtifactV4.call({
+    id: 'upload',
+    with: { name: 'dist', path: 'dist/' },
+  });
+  expect(step.with).toEqual({ name: 'dist', path: 'dist/' });
+  expect(step.uses).toBe('actions/upload-artifact@v4');
+});
+
+test('call() with required + optional inputs', () => {
+  const step = uploadArtifactV4.call({
+    id: 'upload',
+    with: { name: 'dist', path: 'dist/', ifNoFilesFound: 'error' },
+  });
+  expect(step.with).toEqual({ name: 'dist', path: 'dist/', 'if-no-files-found': 'error' });
+});
+
+test('call() with bare-required input (no default, no required:true)', () => {
+  const step = setupAction.call({ id: 'setup', with: { nodeVersion: '20' } });
+  expect(step.with).toEqual({ 'node-version': '20' });
+});
+
+// ─── call() — empty action ──────────────────────────────────────────────────────
+
+test('call() with no inputs and no outputs', () => {
+  const step = emptyAction.call({});
+  expect(step.uses).toBe('actions/empty@v1');
+});
+
+test('call() on no-output action allows omitting id', () => {
+  const step = noOutputAction.call({ with: { inputA: 'val' } });
+  expect(step.uses).toBe('actions/no-output@v1');
+});
+
+// ─── call() — camelCase to kebab-case conversion ────────────────────────────────
+
+test('camelCase input keys are serialized to kebab-case', () => {
+  const step = allOptionalAction.call({ id: 'co', with: { fetchDepth: 0 } });
+  expect(step.with).toEqual({ 'fetch-depth': 0 });
+});
+
+test('multi-word camelCase keys convert correctly', () => {
+  const step = uploadArtifactV4.call({
+    id: 'upload',
+    with: { name: 'dist', path: 'dist/', compressionLevel: '6' },
+  });
+  expect(step.with).toEqual({ name: 'dist', path: 'dist/', 'compression-level': '6' });
+});
+
+// ─── output() ───────────────────────────────────────────────────────────────────
+
+test('output() returns expression string for known output key', () => {
+  const step = allOptionalAction.call({ id: 'co' });
+  const ref = step.output('ref');
+  expect(ref as string).toBe('steps.co.outputs.ref');
+});
+
+test('output() returns expression for another known output key', () => {
+  const step = allOptionalAction.call({ id: 'co' });
+  const commit = step.output('commit');
+  expect(commit as string).toBe('steps.co.outputs.commit');
+});
+
+test('output() on uploadArtifact returns correct expression', () => {
+  const step = uploadArtifactV4.call({ id: 'upload', with: { name: 'dist', path: 'dist/' } });
+  expect(step.output('artifactId') as string).toBe('steps.upload.outputs.artifactId');
+  expect(step.output('artifactUrl') as string).toBe('steps.upload.outputs.artifactUrl');
+});
+
+// ─── Type-Level Tests ───────────────────────────────────────────────────────────
+
+console.log('\nType-level tests (compile-time checks):');
+
+// Valid: all optional inputs, id provided (required because outputs exist)
+const _validStep: TypedUsesStep<{ ref: {}; commit: {} }> = allOptionalAction.call({ id: 'co' });
+
+// Valid: output returns Expression<string>
+const _outputRef: Expression<string> = _validStep.output('ref');
+
+// @ts-expect-error — 'nonexistent' is not an output
+allOptionalAction.call({ id: 'co' }).output('nonexistent');
+
+// @ts-expect-error — 'branchName' is not a valid input
+allOptionalAction.call({ id: 'co', with: { branchName: 'main' } });
+
+// @ts-expect-error — 'name' (required) is missing from upload-artifact with
+uploadArtifactV4.call({ id: 'upload', with: { path: 'dist/' } });
+
+// @ts-expect-error — 'path' (required) is missing from upload-artifact with
+uploadArtifactV4.call({ id: 'upload', with: { name: 'dist' } });
+
+// @ts-expect-error — 'unknownInput' is not a valid input
+uploadArtifactV4.call({ id: 'upload', with: { name: 'dist', path: 'dist/', unknownInput: 'bad' } });
+
+// @ts-expect-error — 'nodeVersion' (bare required) is missing
+setupAction.call({ id: 'setup' });
+
+console.log('  ✓ All @ts-expect-error annotations compile correctly');

--- a/packages/cdkactions/test/action-ref.test.ts
+++ b/packages/cdkactions/test/action-ref.test.ts
@@ -1,8 +1,5 @@
 import { ActionRef, type TypedUsesStep, type Expression } from '../src/index.js';
 
-// ─── Test Fixtures ──────────────────────────────────────────────────────────────
-
-// Action with all-optional inputs (all have defaults) and outputs
 const allOptionalAction = ActionRef.fromReference<
   {
     repository: { default: '${{ github.repository }}' };
@@ -15,7 +12,6 @@ const allOptionalAction = ActionRef.fromReference<
   }
 >('actions/all-optional@v1');
 
-// Action with both required and optional inputs, and outputs
 const uploadArtifactV4 = ActionRef.fromReference<
   {
     name: { required: true };
@@ -29,7 +25,6 @@ const uploadArtifactV4 = ActionRef.fromReference<
   }
 >('actions/upload-artifact@v4');
 
-// Action with required inputs (bare {} = required) and outputs
 const setupAction = ActionRef.fromReference<
   {
     nodeVersion: {};
@@ -40,16 +35,12 @@ const setupAction = ActionRef.fromReference<
   }
 >('actions/setup-node@v4');
 
-// Action with no inputs and no outputs
 const emptyAction = ActionRef.fromReference('actions/empty@v1');
 
-// Action with no outputs (id should be optional)
 const noOutputAction = ActionRef.fromReference<
   { inputA: { required: true } },
   Record<never, never>
 >('actions/no-output@v1');
-
-// ─── Runtime Tests ──────────────────────────────────────────────────────────────
 
 function test(name: string, fn: () => void) {
   try {
@@ -78,8 +69,6 @@ function expect<T>(actual: T) {
 
 console.log('ActionRef');
 
-// ─── fromReference ──────────────────────────────────────────────────────────────
-
 test('fromReference stores the action ref string', () => {
   expect(allOptionalAction.ref).toBe('actions/all-optional@v1');
 });
@@ -88,8 +77,6 @@ test('fromReference with no type params', () => {
   const action = ActionRef.fromReference('my/action@v1');
   expect(action.ref).toBe('my/action@v1');
 });
-
-// ─── call() — basic step shape ──────────────────────────────────────────────────
 
 test('call() produces a step with uses set to the ref', () => {
   const step = allOptionalAction.call({ id: 'co' });
@@ -126,11 +113,8 @@ test('call() sets timeoutMinutes when provided', () => {
   expect(step.timeoutMinutes).toBe(10);
 });
 
-// ─── call() — with inputs ───────────────────────────────────────────────────────
-
 test('call() passes optional inputs in with', () => {
   const step = allOptionalAction.call({ id: 'co', with: { fetchDepth: 0 } });
-  // camelCase keys are converted to kebab-case
   expect(step.with).toEqual({ 'fetch-depth': 0 });
 });
 
@@ -156,8 +140,6 @@ test('call() with bare-required input (no default, no required:true)', () => {
   expect(step.with).toEqual({ 'node-version': '20' });
 });
 
-// ─── call() — empty action ──────────────────────────────────────────────────────
-
 test('call() with no inputs and no outputs', () => {
   const step = emptyAction.call({});
   expect(step.uses).toBe('actions/empty@v1');
@@ -167,8 +149,6 @@ test('call() on no-output action allows omitting id', () => {
   const step = noOutputAction.call({ with: { inputA: 'val' } });
   expect(step.uses).toBe('actions/no-output@v1');
 });
-
-// ─── call() — camelCase to kebab-case conversion ────────────────────────────────
 
 test('camelCase input keys are serialized to kebab-case', () => {
   const step = allOptionalAction.call({ id: 'co', with: { fetchDepth: 0 } });
@@ -182,8 +162,6 @@ test('multi-word camelCase keys convert correctly', () => {
   });
   expect(step.with).toEqual({ name: 'dist', path: 'dist/', 'compression-level': '6' });
 });
-
-// ─── output() ───────────────────────────────────────────────────────────────────
 
 test('output() returns expression string for known output key', () => {
   const step = allOptionalAction.call({ id: 'co' });
@@ -203,14 +181,10 @@ test('output() on uploadArtifact returns correct expression', () => {
   expect(step.output('artifactUrl') as string).toBe('steps.upload.outputs.artifactUrl');
 });
 
-// ─── Type-Level Tests ───────────────────────────────────────────────────────────
-
 console.log('\nType-level tests (compile-time checks):');
 
-// Valid: all optional inputs, id provided (required because outputs exist)
 const _validStep: TypedUsesStep<{ ref: {}; commit: {} }> = allOptionalAction.call({ id: 'co' });
 
-// Valid: output returns Expression<string>
 const _outputRef: Expression<string> = _validStep.output('ref');
 
 // @ts-expect-error — 'nonexistent' is not an output


### PR DESCRIPTION
## Motivation

External GitHub Actions (e.g., `actions/checkout@v4`) are currently referenced with untyped string `uses` and unvalidated `with` maps. Misconfigured inputs or outputs are only caught at runtime (or not at all). This story introduces `ActionRef<TInputs, TOutputs>` — a typed wrapper that catches invalid inputs, missing required inputs, and unknown outputs at compile time.

## Summary

- **`ActionRef<TInputs, TOutputs>`** class with `fromReference()` static factory — define an action's input/output schema once
- **`call(options)`** produces a `TypedUsesStep<TOutputs>` with compile-time enforcement:
  - Required inputs (bare `{}` or `{ required: true }`) must be provided
  - Inputs with `{ default: string }` are optional
  - Unknown input keys are rejected via excess property checks
  - `id` is required when `TOutputs` is non-empty (needed for `${{ steps.<id>.outputs.<key> }}`)
- **`TypedUsesStep.output(key)`** returns `Expression<string>` for valid output keys; unknown keys are compile errors
- **camelCase-to-kebab-case** input key serialization (e.g., `fetchDepth` → `fetch-depth`)
- **`camelToKebab`** utility added to `utils.ts`
- All types exported from `index.ts`

## Test plan

- [ ] `yarn build` passes (typecheck of src)
- [ ] `tsc --noEmit` on test file passes (type-level tests with `@ts-expect-error`)
- [ ] CI passes