### PR TITLE
feat(cdkactions): S04 - Complete event coverage: new events and missing activity types

### DIFF
--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -7,6 +7,13 @@ import type { DefaultsProps, StringMap } from './types.js';
 import { camelToSnake, renameKeys, type Writable } from './utils.js';
 
 /**
+ * Configuration for the BranchProtectionRule event.
+ */
+export interface BranchProtectionRuleTypes {
+  readonly types: Array<'created' | 'edited' | 'deleted'>;
+}
+
+/**
  * Configuration for the CheckRun event.
  */
 export interface CheckRunTypes {
@@ -14,7 +21,29 @@ export interface CheckRunTypes {
 }
 
 export interface CheckSuiteTypes {
-  readonly types: Array<'created' | 'rerequested' | 'requested'>;
+  readonly types: Array<'completed'>;
+}
+
+export interface DiscussionTypes {
+  readonly types: Array<
+    | 'created'
+    | 'edited'
+    | 'deleted'
+    | 'transferred'
+    | 'pinned'
+    | 'unpinned'
+    | 'labeled'
+    | 'unlabeled'
+    | 'locked'
+    | 'unlocked'
+    | 'category_changed'
+    | 'answered'
+    | 'unanswered'
+  >;
+}
+
+export interface DiscussionCommentTypes {
+  readonly types: Array<'created' | 'edited' | 'deleted'>;
 }
 
 export interface IssueCommentTypes {
@@ -39,6 +68,8 @@ export interface IssuesTypes {
     | 'unlocked'
     | 'milestoned'
     | 'demilestoned'
+    | 'typed'
+    | 'untyped'
   >;
 }
 
@@ -79,6 +110,12 @@ export interface PullRequestTypes extends PushTypes {
     | 'review_requested'
     | 'review_request_removed'
     | 'converted_to_draft'
+    | 'enqueued'
+    | 'dequeued'
+    | 'milestoned'
+    | 'demilestoned'
+    | 'auto_merge_enabled'
+    | 'auto_merge_disabled'
   >;
 }
 
@@ -106,6 +143,13 @@ export interface PullRequestTargetTypes {
     | 'unlocked'
     | 'review_requested'
     | 'review_request_removed'
+    | 'converted_to_draft'
+    | 'enqueued'
+    | 'dequeued'
+    | 'milestoned'
+    | 'demilestoned'
+    | 'auto_merge_enabled'
+    | 'auto_merge_disabled'
   >;
 }
 
@@ -143,7 +187,7 @@ export interface WorkflowRunEvent {
     readonly workflows?: string[];
     readonly branches?: string[];
     readonly branchesIgnore?: string[];
-    readonly types?: Array<'completed' | 'requested'>;
+    readonly types?: Array<'completed' | 'requested' | 'in_progress'>;
   };
 }
 
@@ -219,8 +263,11 @@ export type EventStrings =
   | 'status';
 
 export interface EventMap {
+  readonly branchProtectionRule?: BranchProtectionRuleTypes;
   readonly checkRun?: CheckRunTypes;
   readonly checkSuite?: CheckSuiteTypes;
+  readonly discussion?: DiscussionTypes;
+  readonly discussionComment?: DiscussionCommentTypes;
   readonly issueComment?: IssueCommentTypes;
   readonly issues?: IssuesTypes;
   readonly label?: LabelTypes;
@@ -330,8 +377,10 @@ export class Workflow extends Construct {
       branchesIgnore: 'branches-ignore',
       tagsIgnore: 'tags-ignore',
       pathsIgnore: 'paths-ignore',
+      branchProtectionRule: 'branch_protection_rule',
       checkRun: 'check_run',
       checkSuite: 'check_suite',
+      discussionComment: 'discussion_comment',
       issueComment: 'issue_comment',
       mergeGroup: 'merge_group',
       projectCard: 'project_card',

--- a/packages/cdkactions/test/workflow.test.ts
+++ b/packages/cdkactions/test/workflow.test.ts
@@ -1,5 +1,14 @@
 import { Construct } from 'constructs';
 import { Job, WorkflowDispatchInputType } from '../src';
+import type {
+  BranchProtectionRuleTypes,
+  DiscussionTypes,
+  DiscussionCommentTypes,
+  PullRequestTypes,
+  PullRequestTargetTypes,
+  CheckSuiteTypes,
+  IssuesTypes,
+} from '../src';
 import { TestingWorkflow } from './utils';
 
 test('toGHAction', () => {
@@ -96,3 +105,115 @@ test('manual workflow dispatch', () => {
   });
   expect(workflow.toGHAction()).toMatchSnapshot();
 });
+
+test('branch_protection_rule event', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      branchProtectionRule: { types: ['created', 'edited', 'deleted'] },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on).toEqual({
+    branch_protection_rule: { types: ['created', 'edited', 'deleted'] },
+  });
+});
+
+test('discussion event with all 13 activity types', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      discussion: {
+        types: [
+          'created', 'edited', 'deleted', 'transferred',
+          'pinned', 'unpinned', 'labeled', 'unlabeled',
+          'locked', 'unlocked', 'category_changed', 'answered', 'unanswered',
+        ],
+      },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on.discussion.types).toHaveLength(13);
+  expect(ghAction.on.discussion.types).toContain('category_changed');
+});
+
+test('discussion_comment event', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      discussionComment: { types: ['created', 'edited', 'deleted'] },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on).toEqual({
+    discussion_comment: { types: ['created', 'edited', 'deleted'] },
+  });
+});
+
+test('pull_request new activity types', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      pullRequest: {
+        types: ['enqueued', 'dequeued', 'milestoned', 'demilestoned', 'auto_merge_enabled', 'auto_merge_disabled'],
+      },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on.pull_request.types).toEqual([
+    'enqueued', 'dequeued', 'milestoned', 'demilestoned', 'auto_merge_enabled', 'auto_merge_disabled',
+  ]);
+});
+
+test('pull_request_target new activity types', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      pullRequestTarget: {
+        types: ['converted_to_draft', 'enqueued', 'dequeued', 'milestoned', 'demilestoned', 'auto_merge_enabled', 'auto_merge_disabled'],
+      },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on.pull_request_target.types).toEqual([
+    'converted_to_draft', 'enqueued', 'dequeued', 'milestoned', 'demilestoned', 'auto_merge_enabled', 'auto_merge_disabled',
+  ]);
+});
+
+test('check_suite only allows completed', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      checkSuite: { types: ['completed'] },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on.check_suite.types).toEqual(['completed']);
+});
+
+test('workflow_run includes in_progress type', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      workflowRun: {
+        types: ['completed', 'requested', 'in_progress'],
+      },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on.workflow_run.types).toEqual(['completed', 'requested', 'in_progress']);
+});
+
+test('issues includes typed and untyped activity types', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      issues: {
+        types: ['opened', 'typed', 'untyped'],
+      },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on.issues.types).toEqual(['opened', 'typed', 'untyped']);
+});
+
+// Type-level tests: verify CheckSuiteTypes only accepts 'completed'
+// @ts-expect-error - CheckSuiteTypes should not accept 'created'
+const _invalidCheckSuite: CheckSuiteTypes = { types: ['created'] };
+
+// Type-level tests: verify new events exist on EventMap
+const _branchProtection: BranchProtectionRuleTypes = { types: ['created'] };
+const _discussion: DiscussionTypes = { types: ['created', 'answered'] };
+const _discussionComment: DiscussionCommentTypes = { types: ['created'] };


### PR DESCRIPTION
## Motivation

The cdkactions library was missing several GitHub Actions event types and had incorrect/incomplete activity type lists for existing events. This prevents users from configuring workflows that use newer GitHub features like merge queue events, discussion triggers, and branch protection rule automation.

## Summary

- Add `BranchProtectionRuleTypes` interface (created, edited, deleted)
- Add `DiscussionTypes` interface with all 13 activity types
- Add `DiscussionCommentTypes` interface (created, edited, deleted)
- Update `PullRequestTypes` with: enqueued, dequeued, milestoned, demilestoned, auto_merge_enabled, auto_merge_disabled
- Update `PullRequestTargetTypes` with: converted_to_draft, enqueued, dequeued, milestoned, demilestoned, auto_merge_enabled, auto_merge_disabled
- Correct `CheckSuiteTypes` to only accept `completed` per GitHub docs
- Add `in_progress` to `WorkflowRunEvent` types
- Add `typed`, `untyped` to `IssuesTypes`
- Update `EventMap` with new event entries
- Add `renameKeys` mappings for `branchProtectionRule` and `discussionComment`

## Test plan

- [x] Unit tests for all new event types in `toGHAction()` output
- [x] Type-level test: `@ts-expect-error` for `CheckSuiteTypes` with invalid `created` value
- [x] Existing event tests pass unchanged
- [x] Build/typecheck passes