### PR TITLE
feat(cdkactions): S05 - Schedule, WorkflowDispatch, WorkflowCall, and run-name enhancements

### DIFF
--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 
 import { Construct, Node } from 'constructs';
 
+import type { Expression } from './expressions.js';
 import { Job } from './job.js';
 import type { DefaultsProps, StringMap } from './types.js';
 import { camelToSnake, renameKeys, type Writable } from './utils.js';
@@ -178,8 +179,13 @@ export interface MergeGroupTypes {
   readonly types?: Array<'checks_requested'>;
 }
 
+export interface ScheduleEntry {
+  readonly cron: string;
+  readonly timezone?: string;
+}
+
 export interface ScheduleEvent {
-  readonly schedule: [{ cron: string }];
+  readonly schedule: ScheduleEntry[];
 }
 
 export interface WorkflowRunEvent {
@@ -196,6 +202,7 @@ export const WorkflowDispatchInputType = {
   BOOLEAN: 'boolean',
   ENVIRONMENT: 'environment',
   STRING: 'string',
+  NUMBER: 'number',
 } as const;
 
 export type WorkflowDispatchInputType = typeof WorkflowDispatchInputType;
@@ -224,6 +231,10 @@ export interface WorkflowDispatchEventEnvironmentInputProps extends WorkflowDisp
   readonly type: WorkflowDispatchInputType['ENVIRONMENT'];
 }
 
+export interface WorkflowDispatchEventNumberInputProps extends WorkflowDispatchEventInputProps {
+  readonly type: WorkflowDispatchInputType['NUMBER'];
+}
+
 export interface WorkflowDispatchEventProps {
   readonly inputs?: Record<
     string,
@@ -231,6 +242,7 @@ export interface WorkflowDispatchEventProps {
     | WorkflowDispatchEventBooleanInputProps
     | WorkflowDispatchEventStringInputProps
     | WorkflowDispatchEventEnvironmentInputProps
+    | WorkflowDispatchEventNumberInputProps
   >;
 }
 
@@ -242,8 +254,25 @@ export interface MergeGroupEvent {
   readonly mergeGroup: MergeGroupTypes | null;
 }
 
+export type WorkflowCallInputProps =
+  | WorkflowDispatchEventBooleanInputProps
+  | WorkflowDispatchEventStringInputProps
+  | WorkflowDispatchEventNumberInputProps;
+
+export interface WorkflowCallSecretProps {
+  readonly description?: string;
+  readonly required: boolean;
+}
+
+export interface WorkflowCallOutputProps {
+  readonly description: string;
+  readonly value: string;
+}
+
 export interface WorkflowCallEventProps {
-  readonly inputs?: Record<string, WorkflowDispatchEventBooleanInputProps | WorkflowDispatchEventStringInputProps>;
+  readonly inputs?: Record<string, WorkflowCallInputProps>;
+  readonly outputs?: Record<string, WorkflowCallOutputProps>;
+  readonly secrets?: Record<string, WorkflowCallSecretProps>;
 }
 
 export interface WorkflowCallEvent {
@@ -293,6 +322,7 @@ export type TokenPermission = 'read' | 'write' | 'none';
 
 export interface WorkflowProps {
   readonly name: string;
+  readonly runName?: string | Expression<string>;
   readonly on:
     | Events
     | Array<Events>
@@ -374,6 +404,7 @@ export class Workflow extends Construct {
     }
 
     const workflow = renameKeys(this.action, {
+      runName: 'run-name',
       branchesIgnore: 'branches-ignore',
       tagsIgnore: 'tags-ignore',
       pathsIgnore: 'paths-ignore',

--- a/packages/cdkactions/test/workflow.test.ts
+++ b/packages/cdkactions/test/workflow.test.ts
@@ -8,6 +8,12 @@ import type {
   PullRequestTargetTypes,
   CheckSuiteTypes,
   IssuesTypes,
+  WorkflowCallEventProps,
+  WorkflowCallOutputProps,
+  WorkflowCallSecretProps,
+  ScheduleEntry,
+  Expression,
+  WorkflowProps,
 } from '../src';
 import { TestingWorkflow } from './utils';
 
@@ -217,3 +223,124 @@ const _invalidCheckSuite: CheckSuiteTypes = { types: ['created'] };
 const _branchProtection: BranchProtectionRuleTypes = { types: ['created'] };
 const _discussion: DiscussionTypes = { types: ['created', 'answered'] };
 const _discussionComment: DiscussionCommentTypes = { types: ['created'] };
+
+test('schedule with multiple entries and timezone', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      schedule: [
+        { cron: '0 0 * * *' },
+        { cron: '0 12 * * 1-5', timezone: 'America/New_York' },
+        { cron: '30 6 * * 0', timezone: 'Europe/Copenhagen' },
+      ],
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on.schedule).toEqual([
+    { cron: '0 0 * * *' },
+    { cron: '0 12 * * 1-5', timezone: 'America/New_York' },
+    { cron: '30 6 * * 0', timezone: 'Europe/Copenhagen' },
+  ]);
+});
+
+test('workflow_dispatch with number input type', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      workflowDispatch: {
+        inputs: {
+          retries: {
+            description: 'Number of retries',
+            required: true,
+            type: WorkflowDispatchInputType.NUMBER,
+            default: '3',
+          },
+        },
+      },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on.workflow_dispatch.inputs.retries.type).toBe('number');
+});
+
+test('workflow_call with outputs and secrets', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      workflowCall: {
+        inputs: {
+          environment: {
+            description: 'Target environment',
+            required: true,
+            type: WorkflowDispatchInputType.STRING,
+          },
+          count: {
+            description: 'Instance count',
+            required: false,
+            type: WorkflowDispatchInputType.NUMBER,
+          },
+        },
+        outputs: {
+          deployUrl: {
+            description: 'The deployment URL',
+            value: '${{ jobs.deploy.outputs.url }}',
+          },
+        },
+        secrets: {
+          apiKey: {
+            description: 'API key for deployment',
+            required: true,
+          },
+          optionalToken: {
+            required: false,
+          },
+        },
+      },
+    },
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction.on.workflow_call.inputs.environment.type).toBe('string');
+  expect(ghAction.on.workflow_call.inputs.count.type).toBe('number');
+  expect(ghAction.on.workflow_call.outputs.deployUrl).toEqual({
+    description: 'The deployment URL',
+    value: '${{ jobs.deploy.outputs.url }}',
+  });
+  expect(ghAction.on.workflow_call.secrets.apiKey).toEqual({
+    description: 'API key for deployment',
+    required: true,
+  });
+  expect(ghAction.on.workflow_call.secrets.optionalToken).toEqual({
+    required: false,
+  });
+});
+
+test('run-name in synthesized output', () => {
+  const workflow = TestingWorkflow({
+    runName: 'Deploy to production',
+    on: 'push',
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction['run-name']).toBe('Deploy to production');
+  expect(ghAction.runName).toBeUndefined();
+});
+
+test('run-name with Expression<string>', () => {
+  const exprRunName = 'Deploy ${{ inputs.environment }} by ${{ github.actor }}' as Expression<string>;
+  const workflow = TestingWorkflow({
+    runName: exprRunName,
+    on: 'push',
+  });
+  const ghAction = workflow.toGHAction();
+  expect(ghAction['run-name']).toBe('Deploy ${{ inputs.environment }} by ${{ github.actor }}');
+});
+
+// Type-level: WorkflowCallEventProps accepts outputs and secrets
+const _callWithOutputs: WorkflowCallEventProps = {
+  outputs: { url: { description: 'URL', value: 'val' } },
+  secrets: { key: { required: true } },
+};
+
+// Type-level: ScheduleEntry accepts timezone
+const _scheduleWithTz: ScheduleEntry = { cron: '0 0 * * *', timezone: 'UTC' };
+
+// Type-level: runName accepts Expression<string>
+const _propsWithRunName: Pick<WorkflowProps, 'runName'> = {
+  runName: 'test' as Expression<string>,
+};


### PR DESCRIPTION
## Motivation

The current `ScheduleEvent` only accepts a single cron entry (tuple), `WorkflowDispatchInputType` lacks the `number` type, `WorkflowCallEventProps` is missing `outputs` and `secrets`, and there's no way to set `run-name` on workflows. These gaps prevent users from expressing common GitHub Actions patterns.

## Changes

- `ScheduleEvent.schedule` changed from `[{ cron: string }]` to `ScheduleEntry[]` with optional `timezone`
- `WorkflowDispatchInputType` gains `NUMBER` value
- `WorkflowDispatchEventNumberInputProps` interface added
- `WorkflowCallEventProps` gains `outputs: Record<string, WorkflowCallOutputProps>` and `secrets: Record<string, WorkflowCallSecretProps>`
- `WorkflowCallInputProps` type alias added (includes number input type)
- `WorkflowProps.runName` added, serialized as `run-name` via `renameKeys`

## Test plan

- [x] Multiple schedule entries with timezone serialized correctly
- [x] WorkflowDispatch number input type produces `type: 'number'`
- [x] WorkflowCall outputs and secrets serialized correctly
- [x] `run-name` appears in synthesized output, `runName` removed
- [x] Expression<string> accepted for runName
- [x] Type-level tests for new interfaces
- [x] Build passes (tsc)