### PR TITLE
feat(cdkactions): S11 - Condition/Expression integration and addDependency enhancement

### DIFF
--- a/packages/cdkactions/src/job.ts
+++ b/packages/cdkactions/src/job.ts
@@ -111,11 +111,15 @@ export class Condition {
     this.expression = expression;
   }
 
-  static from(condition: string | undefined | null): Condition {
-    if (!condition || condition.trim() === '') {
+  static from(condition: string | Expression<boolean> | undefined | null): Condition {
+    if (!condition || (typeof condition === 'string' && condition.trim() === '')) {
       return new Condition('');
     }
-    return new Condition(condition);
+    return new Condition(String(condition));
+  }
+
+  static fromExpr(expr: Expression<boolean>): Condition {
+    return new Condition(String(expr));
   }
 
   static and(left: Condition | string | undefined, right: Condition | string | undefined): Condition {
@@ -150,6 +154,12 @@ export class Condition {
 
   toString(): string {
     return this.evaluateExpression(this.expression);
+  }
+
+  toExpression(): string {
+    const str = this.toString();
+    if (!str) return '';
+    return `\${{ ${str} }}`;
   }
 
   private evaluateExpression(expr: ConditionExpression): string {
@@ -207,7 +217,7 @@ export interface JobProps<TMatrix extends MatrixDefinition = MatrixDefinition> {
   readonly outputs?: StringMap;
   readonly env?: StringMap;
   readonly defaults?: DefaultsProps;
-  readonly if?: string | Condition;
+  readonly if?: Condition | Expression<boolean>;
   readonly steps?: StepConfig[];
   readonly secrets?: Record<string, string | Expression<string>> | 'inherit';
   readonly timeoutMinutes?: number;
@@ -266,7 +276,11 @@ export class Job<TMatrix extends MatrixDefinition = MatrixDefinition> extends Co
   public toGHAction(): any {
     const { uses, runsOn, steps, strategy, ...rest } = this.action;
 
-    const _if = this.if?.toString() || (this.action.if instanceof Condition ? this.action.if.toString() : this.action.if);
+    const propsIf = this.action.if instanceof Condition ? this.action.if.toString() : (this.action.if ? String(this.action.if) : undefined);
+    const instanceIf = this.if?.toString();
+    const _if = instanceIf && propsIf
+      ? Condition.from(instanceIf).and(Condition.from(propsIf)).toString()
+      : instanceIf || propsIf || undefined;
 
     let serializedRunsOn: unknown = runsOn;
     if (runsOn && typeof runsOn === 'object' && 'group' in runsOn) {
@@ -328,13 +342,27 @@ export class Job<TMatrix extends MatrixDefinition = MatrixDefinition> extends Co
     };
   }
 
-  public addDependency(dependee: Job) {
+  public addDependency(dependee: Job, options?: {
+    condition?: 'success' | 'failure' | 'always' | 'completed';
+  }): this {
     const needs = Array.isArray(this.action.needs) ? this.action.needs : [];
     if (typeof this.action.needs === 'string') {
       needs.push(this.action.needs);
     }
     needs.push(dependee.id);
     this.action.needs = needs;
+
+    if (options?.condition) {
+      const conditionExpr = (options.condition === 'always' || options.condition === 'completed')
+        ? 'always()'
+        : options.condition === 'failure'
+          ? 'failure()'
+          : 'success()';
+
+      const newCondition = Condition.from(conditionExpr);
+      this.if = this.if ? this.if.and(newCondition) : newCondition;
+    }
+
     return this;
   }
 

--- a/packages/cdkactions/test/job.test.ts
+++ b/packages/cdkactions/test/job.test.ts
@@ -1,4 +1,4 @@
-import { Condition, Job, RunnerLabel, createMatrixProxy } from '#@/index.js';
+import { Condition, Job, RunnerLabel, createMatrixProxy, eq, github, always, failure } from '#@/index.js';
 import type { JobProps, ConcurrencyConfig, EnvironmentConfig, RunnerGroupConfig, RunStep, UsesStep, StepConfig, Expression, StrategyProps, MatrixDefinition, ServiceProps } from '#@/index.js';
 
 test('toGHAction', () => {
@@ -471,3 +471,193 @@ const _serviceWithExtras: ServiceProps = {
   entrypoint: '/entrypoint.sh',
 };
 const _serviceWithoutExtras: ServiceProps = { image: 'redis:7' };
+
+test('Condition.from accepts Expression<boolean>', () => {
+  const expr = eq(github.ref, 'refs/heads/main');
+  const condition = Condition.from(expr);
+  expect(condition.toString()).toBe("github.ref == 'refs/heads/main'");
+});
+
+test('Condition.fromExpr creates condition from expression', () => {
+  const expr = eq(github.ref, 'refs/heads/main');
+  const condition = Condition.fromExpr(expr);
+  expect(condition.toString()).toBe("github.ref == 'refs/heads/main'");
+});
+
+test('Condition.toExpression wraps in ${{ }}', () => {
+  const condition = Condition.from("github.ref == 'refs/heads/main'");
+  expect(condition.toExpression()).toBe("${{ github.ref == 'refs/heads/main' }}");
+});
+
+test('Condition.toExpression returns empty string for empty condition', () => {
+  const condition = Condition.from('');
+  expect(condition.toExpression()).toBe('');
+});
+
+test('job if with Expression<boolean> serializes without ${{ }}', () => {
+  const expr = eq(github.ref, 'refs/heads/main');
+  const job = new Job(undefined as any, 'deploy', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    if: expr,
+    steps: [{ run: 'deploy.sh' }],
+  });
+  const ghAction = job.toGHAction();
+  expect(ghAction.if).toBe("github.ref == 'refs/heads/main'");
+});
+
+test('job if with Condition serializes without ${{ }}', () => {
+  const condition = Condition.from("github.ref == 'refs/heads/main'");
+  const job = new Job(undefined as any, 'deploy', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    if: condition,
+    steps: [{ run: 'deploy.sh' }],
+  });
+  const ghAction = job.toGHAction();
+  expect(ghAction.if).toBe("github.ref == 'refs/heads/main'");
+});
+
+test('addDependency with condition: always augments if with always()', () => {
+  const build = new Job(undefined as any, 'build', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'build.sh' }],
+  });
+  const notify = new Job(undefined as any, 'notify', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'notify.sh' }],
+  });
+  notify.addDependency(build, { condition: 'always' });
+
+  const ghAction = notify.toGHAction();
+  expect(ghAction.needs).toEqual(['build']);
+  expect(ghAction.if).toBe('always()');
+});
+
+test('addDependency with condition: failure augments if with failure()', () => {
+  const build = new Job(undefined as any, 'build', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'build.sh' }],
+  });
+  const rollback = new Job(undefined as any, 'rollback', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'rollback.sh' }],
+  });
+  rollback.addDependency(build, { condition: 'failure' });
+
+  const ghAction = rollback.toGHAction();
+  expect(ghAction.needs).toEqual(['build']);
+  expect(ghAction.if).toBe('failure()');
+});
+
+test('addDependency with condition: completed augments if with always()', () => {
+  const build = new Job(undefined as any, 'build', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'build.sh' }],
+  });
+  const cleanup = new Job(undefined as any, 'cleanup', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'cleanup.sh' }],
+  });
+  cleanup.addDependency(build, { condition: 'completed' });
+
+  const ghAction = cleanup.toGHAction();
+  expect(ghAction.if).toBe('always()');
+});
+
+test('addDependency with condition: success augments if with success()', () => {
+  const build = new Job(undefined as any, 'build', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'build.sh' }],
+  });
+  const deploy = new Job(undefined as any, 'deploy', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'deploy.sh' }],
+  });
+  deploy.addDependency(build, { condition: 'success' });
+
+  const ghAction = deploy.toGHAction();
+  expect(ghAction.if).toBe('success()');
+});
+
+test('addDependency without condition does not set if', () => {
+  const build = new Job(undefined as any, 'build', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'build.sh' }],
+  });
+  const test = new Job(undefined as any, 'test', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'test.sh' }],
+  });
+  test.addDependency(build);
+
+  const ghAction = test.toGHAction();
+  expect(ghAction.needs).toEqual(['build']);
+  expect(ghAction.if).toBeUndefined();
+});
+
+test('multiple addDependency with conditions composes if with &&', () => {
+  const build = new Job(undefined as any, 'build', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'build.sh' }],
+  });
+  const test = new Job(undefined as any, 'test', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'test.sh' }],
+  });
+  const notify = new Job(undefined as any, 'notify', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'notify.sh' }],
+  });
+  notify.addDependency(build, { condition: 'always' });
+  notify.addDependency(test, { condition: 'always' });
+
+  const ghAction = notify.toGHAction();
+  expect(ghAction.needs).toEqual(['build', 'test']);
+  expect(ghAction.if).toBe('(always() && always())');
+});
+
+test('job if from props merges with addDependency condition', () => {
+  const build = new Job(undefined as any, 'build', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'build.sh' }],
+  });
+  const deploy = new Job(undefined as any, 'deploy', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    if: eq(github.ref, 'refs/heads/main'),
+    steps: [{ run: 'deploy.sh' }],
+  });
+  deploy.addDependency(build, { condition: 'success' });
+
+  const ghAction = deploy.toGHAction();
+  expect(ghAction.if).toBe("(success() && github.ref == 'refs/heads/main')");
+});
+
+test('Condition composed with Expression via and/or', () => {
+  const cond = Condition.fromExpr(eq(github.ref, 'refs/heads/main'));
+  const alwaysCond = Condition.from('always()');
+  const combined = alwaysCond.and(cond);
+  expect(combined.toString()).toBe("(always() && github.ref == 'refs/heads/main')");
+});
+
+test('step if with Expression emits without ${{ }} wrapping', () => {
+  const expr = eq(github.eventName, 'push');
+  const job = new Job(undefined as any, 'test', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{
+      name: 'Push only',
+      run: 'echo push',
+      if: expr,
+    }],
+  });
+  const ghAction = job.toGHAction();
+  expect(ghAction.steps[0].if).toBe("github.event_name == 'push'");
+});
+
+// Type-level: JobProps.if accepts Condition
+const _jobIfCondition: Pick<JobProps, 'if'> = { if: Condition.from('true') };
+
+// Type-level: JobProps.if accepts Expression<boolean>
+const _jobIfExpr: Pick<JobProps, 'if'> = { if: 'true' as Expression<boolean> };
+
+// Type-level: JobProps.if rejects raw string
+// @ts-expect-error - raw string should not be assignable to Condition | Expression<boolean>
+const _jobIfString: Pick<JobProps, 'if'> = { if: 'raw string' };


### PR DESCRIPTION
## Motivation

GitHub Actions jobs often need conditional execution based on dependency outcomes (e.g., run cleanup on failure, run notifications always). The existing `addDependency` only wires up `needs:` — users had to manually construct `if:` expressions with raw strings, losing type safety.

## Summary

- `Condition.from()` now accepts `Expression<boolean>` in addition to `string`
- Added `Condition.fromExpr(expr)` static method for creating conditions from typed expressions
- Added `Condition.toExpression()` for `${{ }}` wrapping in non-if positions
- `Job.addDependency` gains optional `condition` parameter: `'success' | 'failure' | 'always' | 'completed'`
- Condition augmentation: `'always'` adds `always()`, `'failure'` adds `failure()`, `'success'` adds `success()`
- `if:` positions emit bare expressions (GitHub auto-wraps); other positions use `${{ }}` wrappers
- `JobProps.if` updated to `Condition | Expression<boolean>` (raw strings no longer accepted)

## Test plan

- [x] Unit tests for `Condition.fromExpr()` and `Condition.toExpression()`
- [x] Unit tests for `addDependency` with all condition variants
- [x] Integration tests combining expressions with conditions
- [x] Type-level tests verifying `Expression<boolean>` acceptance