### PR TITLE
feat(cdkactions): S12 - Validation layer

### DIFF
--- a/packages/cdkactions/package.json
+++ b/packages/cdkactions/package.json
@@ -16,7 +16,10 @@
       "types": "./src/*",
       "default": "./dist/*"
     },
-    "#$/*": "./test/*"
+    "#$/*": {
+      "types": "./test/*",
+      "default": "./test/*"
+    }
   },
   "files": [
     "dist"

--- a/packages/cdkactions/src/app.ts
+++ b/packages/cdkactions/src/app.ts
@@ -4,6 +4,7 @@ import { Construct, Node } from 'constructs';
 
 import { CDKActionsStack } from '#@/library.js';
 import { Stack } from '#@/stack.js';
+import { collectValidationErrors } from '#@/validation.js';
 
 /**
  * Configuration for a cdkactions app.
@@ -60,6 +61,11 @@ export class App extends Construct {
    * Synthesizes all manifests into the output directory.
    */
   public synth(): void {
+    const errors = collectValidationErrors(this);
+    if (errors.length > 0) {
+      throw new Error(`Validation failed with ${errors.length} error(s):\n${errors.map(e => `  - ${e}`).join('\n')}`);
+    }
+
     if (!fs.existsSync(this.outdir)) {
       fs.mkdirSync(this.outdir);
     }

--- a/packages/cdkactions/src/index.ts
+++ b/packages/cdkactions/src/index.ts
@@ -7,4 +7,5 @@ export * from '#@/library.js';
 export * from '#@/nominal.js';
 export * from '#@/stack.js';
 export * from '#@/types.js';
+export * from '#@/validation.js';
 export * from '#@/workflow.js';

--- a/packages/cdkactions/src/job.ts
+++ b/packages/cdkactions/src/job.ts
@@ -5,6 +5,7 @@ import type { Expression } from '#@/expressions.js';
 import type { RunnerLabel, Shell } from '#@/nominal.js';
 import type { DefaultsProps, StringMap } from '#@/types.js';
 import { renameKeys, type Writable } from '#@/utils.js';
+import { addJobValidation } from '#@/validation.js';
 import type { Permissions } from '#@/workflow.js';
 import type { Workflow } from '#@/workflow.js';
 
@@ -246,6 +247,13 @@ export class Job<TMatrix extends MatrixDefinition = MatrixDefinition> extends Co
     this.id = id;
     this.action = config as Writable<JobProps<TMatrix>>;
     this.matrix = createMatrixProxy((config.strategy?.matrix ?? {}) as TMatrix);
+    addJobValidation(this, () => ({
+      id: this.id,
+      steps: this.steps,
+      runsOn: this.action.runsOn,
+      uses: this.action.uses,
+      matrix: this.action.strategy?.matrix as Record<string, ReadonlyArray<unknown>> | undefined,
+    }));
   }
 
   get env(): JobProps['env'] {

--- a/packages/cdkactions/src/utils.ts
+++ b/packages/cdkactions/src/utils.ts
@@ -1,6 +1,6 @@
 import type { StringMap } from '#@/types.js';
 
-export type Writable<T> = T extends object ? { -readonly [K in keyof T]: Writable<T[K]> } : T;
+export type Writable<T> = T extends Function ? T : T extends object ? { -readonly [K in keyof T]: Writable<T[K]> } : T;
 
 /**
  * A helper function to recursively rename keys within an object

--- a/packages/cdkactions/src/validation.ts
+++ b/packages/cdkactions/src/validation.ts
@@ -1,0 +1,183 @@
+import { Construct, Node, type IValidation } from 'constructs';
+
+const CRON_FIELD_RANGES: Array<{ name: string; min: number; max: number }> = [
+  { name: 'minute', min: 0, max: 59 },
+  { name: 'hour', min: 0, max: 23 },
+  { name: 'day of month', min: 1, max: 31 },
+  { name: 'month', min: 1, max: 12 },
+  { name: 'day of week', min: 0, max: 6 },
+];
+
+function validateCronField(field: string, range: { name: string; min: number; max: number }): string | undefined {
+  if (field === '*') return undefined;
+
+  for (const part of field.split(',')) {
+    const stepMatch = part.match(/^(.+)\/(\d+)$/);
+    const base = stepMatch ? stepMatch[1] : part;
+    const step = stepMatch ? parseInt(stepMatch[2], 10) : undefined;
+
+    if (step !== undefined && (step < 1 || !Number.isFinite(step))) {
+      return `Invalid step value '${step}' in ${range.name} field`;
+    }
+
+    if (base === '*') continue;
+
+    const rangeMatch = base.match(/^(\d+)-(\d+)$/);
+    if (rangeMatch) {
+      const [, startStr, endStr] = rangeMatch;
+      const start = parseInt(startStr, 10);
+      const end = parseInt(endStr, 10);
+      if (start < range.min || start > range.max) {
+        return `${range.name} range start ${start} is outside ${range.min}-${range.max}`;
+      }
+      if (end < range.min || end > range.max) {
+        return `${range.name} range end ${end} is outside ${range.min}-${range.max}`;
+      }
+      if (start > end) {
+        return `${range.name} range ${start}-${end} has start greater than end`;
+      }
+      continue;
+    }
+
+    const num = parseInt(base, 10);
+    if (isNaN(num) || String(num) !== base) {
+      return `Invalid ${range.name} value '${base}'`;
+    }
+    if (num < range.min || num > range.max) {
+      return `${range.name} value ${num} is outside ${range.min}-${range.max}`;
+    }
+  }
+
+  return undefined;
+}
+
+export function validateCronExpression(cron: string): string[] {
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    return [`Cron expression '${cron}' must have exactly 5 fields, got ${fields.length}`];
+  }
+
+  const errors: string[] = [];
+  for (let i = 0; i < 5; i++) {
+    const error = validateCronField(fields[i], CRON_FIELD_RANGES[i]);
+    if (error) {
+      errors.push(`Cron expression '${cron}': ${error}`);
+    }
+  }
+  return errors;
+}
+
+export interface JobValidationData {
+  readonly id: string;
+  readonly steps: ReadonlyArray<{ readonly id?: string; readonly name?: string; readonly run?: unknown; readonly uses?: unknown }>;
+  readonly runsOn?: unknown;
+  readonly uses?: unknown;
+  readonly matrix?: Record<string, ReadonlyArray<unknown>>;
+}
+
+class JobValidation implements IValidation {
+  constructor(private readonly data: () => JobValidationData) {}
+
+  validate(): string[] {
+    const data = this.data();
+    const errors: string[] = [];
+
+    for (const step of data.steps) {
+      if (step.run !== undefined && step.uses !== undefined) {
+        const stepId = step.id || step.name || '(unnamed)';
+        errors.push(
+          `Job '${data.id}' step '${stepId}': 'run' and 'uses' are mutually exclusive — use one or the other`,
+        );
+      }
+    }
+
+    if (!data.runsOn && !data.uses) {
+      errors.push(
+        `Job '${data.id}': 'runsOn' is required unless 'uses' (reusable workflow) is set`,
+      );
+    }
+
+    if (data.matrix) {
+      const keys = Object.keys(data.matrix);
+      if (keys.length > 0) {
+        let combinations = 1;
+        for (const key of keys) {
+          const values = data.matrix[key];
+          if (Array.isArray(values)) {
+            combinations *= values.length;
+          }
+        }
+        if (combinations > 256) {
+          errors.push(
+            `Job '${data.id}': matrix produces ${combinations} combinations, exceeding GitHub's limit of 256`,
+          );
+        }
+      }
+    }
+
+    if (data.steps.length > 1000) {
+      errors.push(
+        `Job '${data.id}': has ${data.steps.length} steps, exceeding the recommended limit of 1000`,
+      );
+    }
+
+    return errors;
+  }
+}
+
+export interface WorkflowValidationData {
+  readonly name: string;
+  readonly on: unknown;
+}
+
+class WorkflowValidation implements IValidation {
+  constructor(private readonly data: () => WorkflowValidationData) {}
+
+  validate(): string[] {
+    const data = this.data();
+    const errors: string[] = [];
+
+    const on = data.on;
+    if (typeof on === 'object' && on !== null && !Array.isArray(on)) {
+      for (const [name, config] of Object.entries(on as Record<string, unknown>)) {
+        if (!config || typeof config !== 'object') continue;
+        const pushLike = config as { branches?: unknown[]; branchesIgnore?: unknown[] };
+        if (pushLike.branches?.length && pushLike.branchesIgnore?.length) {
+          errors.push(
+            `Workflow '${data.name}' event '${name}': 'branches' and 'branchesIgnore' are mutually exclusive`,
+          );
+        }
+      }
+
+      if ('schedule' in on) {
+        const schedule = (on as { schedule: Array<{ cron: string }> }).schedule;
+        for (const entry of schedule) {
+          for (const cronError of validateCronExpression(entry.cron)) {
+            errors.push(`Workflow '${data.name}': ${cronError}`);
+          }
+        }
+      }
+    }
+
+    return errors;
+  }
+}
+
+export function addJobValidation(construct: Construct, getData: () => JobValidationData): void {
+  Node.of(construct).addValidation(new JobValidation(getData));
+}
+
+export function addWorkflowValidation(construct: Construct, getData: () => WorkflowValidationData): void {
+  Node.of(construct).addValidation(new WorkflowValidation(getData));
+}
+
+export function collectValidationErrors(construct: Construct): string[] {
+  const root = Node.of(construct);
+  const errors: string[] = [];
+
+  for (const child of root.findAll()) {
+    errors.push(...Node.of(child).validate());
+  }
+
+  return errors;
+}

--- a/packages/cdkactions/src/validation.ts
+++ b/packages/cdkactions/src/validation.ts
@@ -1,5 +1,57 @@
 import { Construct, Node, type IValidation } from 'constructs';
 
+type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+
+type MinuteValue = `${Digit}` | `${1 | 2 | 3 | 4 | 5}${Digit}`;
+type HourValue = `${Digit}` | `1${Digit}` | `2${'0' | '1' | '2' | '3'}`;
+type DayOfMonthValue =
+  | `${Exclude<Digit, '0'>}`
+  | `${'1' | '2'}${Digit}`
+  | '30'
+  | '31';
+type MonthValue =
+  | `${Exclude<Digit, '0'>}`
+  | '10'
+  | '11'
+  | '12'
+  | 'JAN' | 'FEB' | 'MAR' | 'APR' | 'MAY' | 'JUN'
+  | 'JUL' | 'AUG' | 'SEP' | 'OCT' | 'NOV' | 'DEC';
+type WeekdayValue =
+  | '0' | '1' | '2' | '3' | '4' | '5' | '6'
+  | 'SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT';
+
+type IsAtom<S extends string, V extends string> =
+  S extends V ? true :
+  S extends `*/${infer Step}` ? (Step extends V ? true : false) :
+  S extends `${infer Lo}-${infer Rest}` ? (
+    Rest extends `${infer Hi}/${infer Step}`
+      ? (Lo extends V ? Hi extends V ? Step extends V ? true : false : false : false)
+      : (Lo extends V ? Rest extends V ? true : false : false)
+  ) :
+  false;
+
+type IsField<S extends string, V extends string> =
+  S extends '*' ? true :
+  S extends `${infer Head},${infer Tail}`
+    ? (IsAtom<Head, V> extends true ? IsField<Tail, V> : false)
+    : IsAtom<S, V>;
+
+type IsValidCron<S extends string> =
+  S extends `${infer Min} ${infer R1}`
+    ? R1 extends `${infer Hr} ${infer R2}`
+      ? R2 extends `${infer Dom} ${infer R3}`
+        ? R3 extends `${infer Mon} ${infer Wday}`
+          ? Wday extends `${string} ${string}` ? false
+            : [IsField<Min, MinuteValue>, IsField<Hr, HourValue>, IsField<Dom, DayOfMonthValue>, IsField<Mon, MonthValue>, IsField<Wday, WeekdayValue>] extends [true, true, true, true, true]
+              ? true
+              : false
+          : false
+        : false
+      : false
+    : false;
+
+export type ValidCronExpression<S extends string> = IsValidCron<S> extends true ? S : never;
+
 const CRON_FIELD_RANGES: Array<{ name: string; min: number; max: number }> = [
   { name: 'minute', min: 0, max: 59 },
   { name: 'hour', min: 0, max: 23 },
@@ -51,7 +103,7 @@ function validateCronField(field: string, range: { name: string; min: number; ma
   return undefined;
 }
 
-export function validateCronExpression(cron: string): string[] {
+function validateCronString(cron: string): string[] {
   const fields = cron.trim().split(/\s+/);
   if (fields.length !== 5) {
     return [`Cron expression '${cron}' must have exactly 5 fields, got ${fields.length}`];
@@ -65,6 +117,37 @@ export function validateCronExpression(cron: string): string[] {
     }
   }
   return errors;
+}
+
+export class CronExpression<S extends string = string> {
+  readonly expression: S;
+
+  constructor(expression: ValidCronExpression<S>) {
+    const errors = validateCronString(expression);
+    if (errors.length > 0) {
+      throw new Error(errors.join('; '));
+    }
+    this.expression = expression as S;
+  }
+
+  static from(expression: string): CronExpression {
+    const errors = validateCronString(expression);
+    if (errors.length > 0) {
+      throw new Error(errors.join('; '));
+    }
+    const instance = Object.create(CronExpression.prototype) as CronExpression;
+    (instance as { expression: string }).expression = expression;
+    return instance;
+  }
+
+  toString(): string {
+    return this.expression;
+  }
+}
+
+export function validateCronExpression(cron: string | CronExpression): string[] {
+  const value = cron instanceof CronExpression ? cron.expression : cron;
+  return validateCronString(value);
 }
 
 export interface JobValidationData {
@@ -150,8 +233,9 @@ class WorkflowValidation implements IValidation {
       }
 
       if ('schedule' in on) {
-        const schedule = (on as { schedule: Array<{ cron: string }> }).schedule;
+        const schedule = (on as { schedule: Array<{ cron: string | CronExpression }> }).schedule;
         for (const entry of schedule) {
+          if (entry.cron instanceof CronExpression) continue;
           for (const cronError of validateCronExpression(entry.cron)) {
             errors.push(`Workflow '${data.name}': ${cronError}`);
           }

--- a/packages/cdkactions/src/validation.ts
+++ b/packages/cdkactions/src/validation.ts
@@ -130,16 +130,6 @@ export class CronExpression<S extends string = string> {
     this.expression = expression as S;
   }
 
-  static from(expression: string): CronExpression {
-    const errors = validateCronString(expression);
-    if (errors.length > 0) {
-      throw new Error(errors.join('; '));
-    }
-    const instance = Object.create(CronExpression.prototype) as CronExpression;
-    (instance as { expression: string }).expression = expression;
-    return instance;
-  }
-
   toString(): string {
     return this.expression;
   }

--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -6,7 +6,7 @@ import type { Expression } from '#@/expressions.js';
 import { Job, type ConcurrencyConfig } from '#@/job.js';
 import type { DefaultsProps, StringMap } from '#@/types.js';
 import { camelToSnake, renameKeys, type Writable } from '#@/utils.js';
-import { addWorkflowValidation } from '#@/validation.js';
+import { CronExpression, addWorkflowValidation } from '#@/validation.js';
 
 /**
  * Configuration for the BranchProtectionRule event.
@@ -181,7 +181,7 @@ export interface MergeGroupTypes {
 }
 
 export interface ScheduleEntry {
-  readonly cron: string;
+  readonly cron: string | CronExpression;
   readonly timezone?: string;
 }
 
@@ -407,6 +407,13 @@ export class Workflow extends Construct {
 
     if (typeof this.action.on !== 'string' && 'workflowRun' in this.action.on) {
       assert(this.action.on.workflowRun.workflows?.length, `${this.action.name} must specify workflows it depends on`);
+    }
+
+    if (typeof this.action.on === 'object' && !Array.isArray(this.action.on) && 'schedule' in this.action.on) {
+      this.action.on.schedule = this.action.on.schedule.map((entry) => ({
+        ...entry,
+        cron: entry.cron instanceof CronExpression ? entry.cron.toString() : entry.cron,
+      }));
     }
 
     const workflow = renameKeys(this.action, {

--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -6,6 +6,7 @@ import type { Expression } from '#@/expressions.js';
 import { Job, type ConcurrencyConfig } from '#@/job.js';
 import type { DefaultsProps, StringMap } from '#@/types.js';
 import { camelToSnake, renameKeys, type Writable } from '#@/utils.js';
+import { addWorkflowValidation } from '#@/validation.js';
 
 /**
  * Configuration for the BranchProtectionRule event.
@@ -376,6 +377,10 @@ export class Workflow extends Construct {
     super(scope, id);
     this.action = config;
     this.outputFile = `cdkactions_${sanitizedId}.yaml`;
+    addWorkflowValidation(this, () => ({
+      name: this.action.name,
+      on: this.action.on,
+    }));
   }
 
   public addDependency(dependee: Workflow) {

--- a/packages/cdkactions/test/validation.test.ts
+++ b/packages/cdkactions/test/validation.test.ts
@@ -1,8 +1,8 @@
 import { Node } from 'constructs';
 
-import { App, Stack, Workflow, Job, RunnerLabel, validateCronExpression, collectValidationErrors } from '#@/index.js';
+import { App, Stack, Workflow, Job, RunnerLabel, CronExpression, validateCronExpression, collectValidationErrors } from '#@/index.js';
 import type { StepConfig, ScheduleEvent, WorkflowProps } from '#@/index.js';
-import { TestingApp } from '#$/utils.js';
+import { TestingApp } from './utils.js';
 
 function createTestApp(options: { createValidateWorkflow?: boolean } = {}) {
   return TestingApp({ createValidateWorkflow: false, ...options });
@@ -328,4 +328,78 @@ test('multiple validation errors collected', () => {
 
   const errors = collectValidationErrors(app);
   expect(errors.filter(e => e.includes("'runsOn' is required"))).toHaveLength(2);
+});
+
+test('CronExpression: valid expression creates instance', () => {
+  const cron = new CronExpression('0 0 * * *');
+  expect(cron.expression).toBe('0 0 * * *');
+  expect(cron.toString()).toBe('0 0 * * *');
+});
+
+test('CronExpression: complex valid expressions', () => {
+  expect(new CronExpression('*/15 * * * *').toString()).toBe('*/15 * * * *');
+  expect(new CronExpression('0 9 * * 1-5').toString()).toBe('0 9 * * 1-5');
+  expect(new CronExpression('30 4 1,15 * *').toString()).toBe('30 4 1,15 * *');
+});
+
+test('CronExpression: throws on invalid expression', () => {
+  expect(() => new CronExpression('0 25 * * *')).toThrow('hour');
+  expect(() => new CronExpression('0 0 * *')).toThrow('must have exactly 5 fields');
+  expect(() => new CronExpression('60 0 * * *')).toThrow('minute');
+});
+
+test('CronExpression: used in ScheduleEntry', () => {
+  const app = createTestApp();
+  const stack = new Stack(app, 'cron-stack');
+  new Workflow(stack, 'cron-workflow', {
+    name: 'Cron Test',
+    on: {
+      schedule: [{ cron: new CronExpression('0 0 * * *') }],
+    },
+  } as unknown as WorkflowProps);
+
+  const errors = collectValidationErrors(app);
+  expect(errors).toHaveLength(0);
+});
+
+test('CronExpression: serializes to string in toGHAction', () => {
+  const app = createTestApp();
+  const stack = new Stack(app, 'cron-stack');
+  const workflow = new Workflow(stack, 'cron-workflow', {
+    name: 'Cron Test',
+    on: {
+      schedule: [{ cron: new CronExpression('*/15 * * * *') }],
+    },
+  } as unknown as WorkflowProps);
+  new Job(workflow, 'test-job', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'echo test' }],
+  });
+
+  const output = workflow.toGHAction();
+  expect(output.on.schedule[0].cron).toBe('*/15 * * * *');
+});
+
+function _cronTypeTests() {
+  // @ts-expect-error — invalid cron expression caught at compile time
+  new CronExpression('invalid cron');
+  // @ts-expect-error — too few fields
+  new CronExpression('0 0 * *');
+  // @ts-expect-error — hour 25 out of range
+  new CronExpression('0 25 * * *');
+
+  new CronExpression('0 0 * * *');
+  new CronExpression('*/15 * * * *');
+}
+void _cronTypeTests;
+
+test('CronExpression.from: creates instance from dynamic string', () => {
+  const dynamic = '0 0 * * *';
+  const cron = CronExpression.from(dynamic);
+  expect(cron).toBeInstanceOf(CronExpression);
+  expect(cron.toString()).toBe('0 0 * * *');
+});
+
+test('CronExpression.from: throws on invalid dynamic string', () => {
+  expect(() => CronExpression.from('0 25 * * *')).toThrow('hour');
 });

--- a/packages/cdkactions/test/validation.test.ts
+++ b/packages/cdkactions/test/validation.test.ts
@@ -2,7 +2,7 @@ import { Node } from 'constructs';
 
 import { App, Stack, Workflow, Job, RunnerLabel, CronExpression, validateCronExpression, collectValidationErrors } from '#@/index.js';
 import type { StepConfig, ScheduleEvent, WorkflowProps } from '#@/index.js';
-import { TestingApp } from './utils.js';
+import { TestingApp } from '#$/utils.js';
 
 function createTestApp(options: { createValidateWorkflow?: boolean } = {}) {
   return TestingApp({ createValidateWorkflow: false, ...options });

--- a/packages/cdkactions/test/validation.test.ts
+++ b/packages/cdkactions/test/validation.test.ts
@@ -1,0 +1,331 @@
+import { Node } from 'constructs';
+
+import { App, Stack, Workflow, Job, RunnerLabel, validateCronExpression, collectValidationErrors } from '#@/index.js';
+import type { StepConfig, ScheduleEvent, WorkflowProps } from '#@/index.js';
+import { TestingApp } from '#$/utils.js';
+
+function createTestApp(options: { createValidateWorkflow?: boolean } = {}) {
+  return TestingApp({ createValidateWorkflow: false, ...options });
+}
+
+function createTestWorkflow(app: App, workflowProps: Partial<WorkflowProps> = {}) {
+  const stack = new Stack(app, 'test-stack');
+  return new Workflow(stack, 'test-workflow', {
+    name: 'Test',
+    on: 'push',
+    ...workflowProps,
+  });
+}
+
+test('step mutual exclusion: run and uses both set', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'bad-job', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{
+      id: 'bad-step',
+      run: 'echo hello',
+      uses: 'actions/checkout@v4',
+    } as unknown as StepConfig],
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain("'run' and 'uses' are mutually exclusive");
+  expect(errors[0]).toContain('bad-step');
+});
+
+test('step mutual exclusion: uses step name in error message', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'bad-job', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{
+      name: 'My Step',
+      run: 'echo hello',
+      uses: 'actions/checkout@v4',
+    } as unknown as StepConfig],
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors[0]).toContain('My Step');
+});
+
+test('step mutual exclusion: valid steps pass', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'good-job', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [
+      { run: 'echo hello' },
+      { uses: 'actions/checkout@v4' },
+    ],
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors).toHaveLength(0);
+});
+
+test('runsOn required when uses not set', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'no-runner', {
+    steps: [{ run: 'echo hello' }],
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors.some(e => e.includes("'runsOn' is required"))).toBe(true);
+});
+
+test('runsOn not required when uses (reusable workflow) is set', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'reusable', {
+    uses: 'org/repo/.github/workflows/reusable.yml@main',
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors.filter(e => e.includes("'runsOn' is required"))).toHaveLength(0);
+});
+
+test('matrix size warning: exceeds 256 combinations', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'big-matrix', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    strategy: {
+      matrix: {
+        os: ['ubuntu', 'windows', 'macos'] as const,
+        node: ['14', '16', '18', '20'] as const,
+        arch: ['x64', 'arm64'] as const,
+        variant: Array.from({ length: 12 }, (_, i) => `v${i}`) as unknown as readonly string[],
+      },
+    },
+    steps: [{ run: 'echo test' }],
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors.some(e => e.includes('exceeding GitHub\'s limit of 256'))).toBe(true);
+});
+
+test('matrix size: within 256 passes', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'ok-matrix', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    strategy: {
+      matrix: {
+        os: ['ubuntu', 'windows'] as const,
+        node: ['18', '20'] as const,
+      },
+    },
+    steps: [{ run: 'echo test' }],
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors).toHaveLength(0);
+});
+
+test('step limit: exceeds 1000 steps', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  const steps: StepConfig[] = Array.from({ length: 1001 }, (_, i) => ({
+    run: `echo step ${i}`,
+  }));
+  new Job(workflow, 'many-steps', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps,
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors.some(e => e.includes('exceeding the recommended limit of 1000'))).toBe(true);
+});
+
+test('step limit: exactly 1000 steps passes', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  const steps: StepConfig[] = Array.from({ length: 1000 }, (_, i) => ({
+    run: `echo step ${i}`,
+  }));
+  new Job(workflow, 'many-steps', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps,
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors).toHaveLength(0);
+});
+
+test('branches and branchesIgnore mutual exclusion on push event', () => {
+  const app = createTestApp();
+  createTestWorkflow(app, {
+    on: {
+      push: {
+        branches: ['main'],
+        branchesIgnore: ['feature/*'],
+      },
+    },
+  } as unknown as Partial<WorkflowProps>);
+
+  const errors = collectValidationErrors(app);
+  expect(errors.some(e => e.includes("'branches' and 'branchesIgnore' are mutually exclusive"))).toBe(true);
+});
+
+test('branches and branchesIgnore mutual exclusion on pullRequest event', () => {
+  const app = createTestApp();
+  createTestWorkflow(app, {
+    on: {
+      pullRequest: {
+        branches: ['main'],
+        branchesIgnore: ['feature/*'],
+      },
+    },
+  } as unknown as Partial<WorkflowProps>);
+
+  const errors = collectValidationErrors(app);
+  expect(errors.some(e => e.includes("'branches' and 'branchesIgnore' are mutually exclusive"))).toBe(true);
+});
+
+test('branches without branchesIgnore passes', () => {
+  const app = createTestApp();
+  createTestWorkflow(app, {
+    on: {
+      push: {
+        branches: ['main'],
+      },
+    },
+  } as unknown as Partial<WorkflowProps>);
+
+  const errors = collectValidationErrors(app);
+  expect(errors).toHaveLength(0);
+});
+
+test('cron validation: valid expressions pass', () => {
+  expect(validateCronExpression('0 0 * * *')).toHaveLength(0);
+  expect(validateCronExpression('*/15 * * * *')).toHaveLength(0);
+  expect(validateCronExpression('0 9 * * 1-5')).toHaveLength(0);
+  expect(validateCronExpression('30 4 1,15 * *')).toHaveLength(0);
+});
+
+test('cron validation: wrong number of fields', () => {
+  const errors = validateCronExpression('0 0 * *');
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain('must have exactly 5 fields');
+});
+
+test('cron validation: out of range values', () => {
+  const errors = validateCronExpression('60 0 * * *');
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain('minute');
+  expect(errors[0]).toContain('outside 0-59');
+});
+
+test('cron validation: invalid hour', () => {
+  const errors = validateCronExpression('0 25 * * *');
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain('hour');
+});
+
+test('cron validation: invalid day of month', () => {
+  const errors = validateCronExpression('0 0 32 * *');
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain('day of month');
+});
+
+test('cron validation: invalid month', () => {
+  const errors = validateCronExpression('0 0 * 13 *');
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain('month');
+});
+
+test('cron validation: invalid day of week', () => {
+  const errors = validateCronExpression('0 0 * * 7');
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain('day of week');
+});
+
+test('cron validation: invalid range', () => {
+  const errors = validateCronExpression('5-2 * * * *');
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toContain('start greater than end');
+});
+
+test('cron validation integrated with workflow', () => {
+  const app = createTestApp();
+  const stack = new Stack(app, 'cron-stack');
+  new Workflow(stack, 'cron-workflow', {
+    name: 'Cron Test',
+    on: {
+      schedule: [{ cron: '0 25 * * *' }],
+    },
+  } as unknown as WorkflowProps);
+
+  const errors = collectValidationErrors(app);
+  expect(errors.some(e => e.includes('hour'))).toBe(true);
+});
+
+test('valid cron in workflow passes', () => {
+  const app = createTestApp();
+  const stack = new Stack(app, 'cron-stack');
+  new Workflow(stack, 'cron-workflow', {
+    name: 'Cron Test',
+    on: {
+      schedule: [{ cron: '0 0 * * *' }],
+    },
+  } as unknown as WorkflowProps);
+
+  const errors = collectValidationErrors(app);
+  expect(errors).toHaveLength(0);
+});
+
+test('validations run during app.synth() and throw', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'invalid', {
+    steps: [{ run: 'echo hello' }],
+  });
+
+  expect(() => app.synth()).toThrow('Validation failed');
+});
+
+test('app.synth() succeeds with valid constructs', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'valid', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [{ run: 'echo hello' }],
+  });
+
+  expect(() => app.synth()).not.toThrow();
+});
+
+test('validation error messages are actionable', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'my-job', {
+    steps: [{
+      id: 'conflicting',
+      run: 'echo hello',
+      uses: 'actions/checkout@v4',
+    } as unknown as StepConfig],
+  });
+
+  const errors = collectValidationErrors(app);
+  for (const error of errors) {
+    expect(error).toMatch(/Job '.+'/);
+  }
+});
+
+test('multiple validation errors collected', () => {
+  const app = createTestApp();
+  const workflow = createTestWorkflow(app);
+  new Job(workflow, 'job1', {
+    steps: [{ run: 'echo hello' }],
+  });
+  new Job(workflow, 'job2', {
+    steps: [{ run: 'echo hello' }],
+  });
+
+  const errors = collectValidationErrors(app);
+  expect(errors.filter(e => e.includes("'runsOn' is required"))).toHaveLength(2);
+});

--- a/packages/cdkactions/test/validation.test.ts
+++ b/packages/cdkactions/test/validation.test.ts
@@ -2,7 +2,7 @@ import { Node } from 'constructs';
 
 import { App, Stack, Workflow, Job, RunnerLabel, CronExpression, validateCronExpression, collectValidationErrors } from '#@/index.js';
 import type { StepConfig, ScheduleEvent, WorkflowProps } from '#@/index.js';
-import { TestingApp } from '#$/utils.js';
+import { TestingApp } from './utils.js';
 
 function createTestApp(options: { createValidateWorkflow?: boolean } = {}) {
   return TestingApp({ createValidateWorkflow: false, ...options });
@@ -393,13 +393,13 @@ function _cronTypeTests() {
 }
 void _cronTypeTests;
 
-test('CronExpression.from: creates instance from dynamic string', () => {
-  const dynamic = '0 0 * * *';
-  const cron = CronExpression.from(dynamic);
+test('CronExpression constructor: creates instance from dynamic string', () => {
+  const dynamic = '0 0 * * *' as string;
+  const cron = new CronExpression(dynamic);
   expect(cron).toBeInstanceOf(CronExpression);
   expect(cron.toString()).toBe('0 0 * * *');
 });
 
-test('CronExpression.from: throws on invalid dynamic string', () => {
-  expect(() => CronExpression.from('0 25 * * *')).toThrow('hour');
+test('CronExpression constructor: throws on invalid dynamic string', () => {
+  expect(() => new CronExpression('0 25 * * *' as string)).toThrow('hour');
 });


### PR DESCRIPTION
## Motivation

Without validation, misconfigured workflows silently produce invalid YAML that fails at GitHub Actions runtime — a slow, frustrating feedback loop. This adds compile-time validation that catches common mistakes immediately during `app.synth()`.

## Summary

- Add `validation.ts` with construct-level validations via `Node.addValidation()` from the `constructs` library
- Validations run automatically during `app.synth()` before writing YAML files
- Failed validations throw with actionable error messages identifying the construct and issue

### Validation rules
- **Step mutual exclusion:** `run` and `uses` cannot both be set on a step
- **Branch mutual exclusion:** `branches` and `branchesIgnore` on the same event
- **Required field:** `runsOn` is required unless `uses` (reusable workflow) is set
- **Matrix size:** error if matrix produces > 256 job combinations (GitHub's limit)
- **Step limit:** error if a job has > 1000 steps
- **Cron validation:** validates POSIX cron expression syntax (field count, value ranges, steps, ranges)

### Files changed
- `src/validation.ts` — validation logic (new)
- `src/app.ts` — call `collectValidationErrors()` in `synth()`
- `src/job.ts` — register `JobValidation` in constructor
- `src/workflow.ts` — register `WorkflowValidation` in constructor
- `src/index.ts` — re-export validation module
- `test/validation.test.ts` — unit tests for every validation rule

Closes S12.