### PR TITLE
docs: update README and getting-started with current API patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install @factbird/cdkactions constructs
 ```
 
 ```typescript
-import { App, Stack, Workflow, Job, RunnerLabel } from '@factbird/cdkactions';
+import { App, Stack, Workflow, Job, RunnerLabel, checkoutV4 } from '@factbird/cdkactions';
 
 const app = new App();
 const stack = new Stack(app, 'ci');
@@ -37,7 +37,7 @@ const workflow = new Workflow(stack, 'build', {
 new Job(workflow, 'test', {
   runsOn: RunnerLabel.UBUNTU_LATEST,
   steps: [
-    { uses: 'actions/checkout@v4' },
+    checkoutV4(),
     { name: 'Install', run: 'npm ci' },
     { name: 'Test', run: 'npm test' },
   ],
@@ -48,80 +48,98 @@ app.synth();
 
 Run `npx ts-node main.ts` (or `bun run main.ts`) to produce `.github/workflows/cdkactions_build.yaml`.
 
+## Typed Expressions
+
+Context proxies give you autocomplete on all GitHub Actions contexts. Expressions are automatically wrapped in `${{ }}` during synthesis — no manual wrapping needed.
+
+```typescript
+import { expression, eq, not, and } from '@factbird/cdkactions';
+
+const { github, secrets, env } = expression;
+
+// Context proxies — autocomplete on github.ref, github.actor, etc.
+github.ref           // Expression<string>
+secrets.GITHUB_TOKEN // Expression<string>
+
+// Compose with operators — returns Expression<boolean>
+const isMain = eq(github.ref, 'refs/heads/main');
+const deployCondition = and(isMain, not(eq(github.actor, 'dependabot[bot]')));
+
+// Use anywhere — auto-wrapped during synthesis
+new Job(workflow, 'push', {
+  runsOn: RunnerLabel.UBUNTU_LATEST,
+  if: deployCondition,
+  steps: [{
+    name: 'Login',
+    uses: 'docker/login-action@v3',
+    with: {
+      username: github.actor,        // → ${{ github.actor }}
+      password: secrets.GITHUB_TOKEN, // → ${{ secrets.GITHUB_TOKEN }}
+    },
+  }],
+});
+
+// Template literals work too
+{ concurrency: { group: `deploy-${github.ref}` } }
+// → "deploy-${{ github.ref }}"
+```
+
+## Typed Action References
+
+Pre-defined actions enforce required inputs, reject unknown keys, and give typed `.output()` access — all at compile time.
+
+```typescript
+import { checkoutV4, uploadArtifactV4, setupNodeV6 } from '@factbird/cdkactions';
+
+// Callable — all-optional inputs means the parameter is optional
+const co = checkoutV4({ id: 'co', with: { fetchDepth: 0 } });
+co.output('commit'); // ✓ declared output
+// co.output('digest'); // ✗ compile error — not a declared output
+
+// Required inputs are enforced
+const upload = uploadArtifactV4({
+  id: 'upload',
+  with: { name: 'dist', path: 'dist/' }, // name and path are required
+});
+
+new Job(workflow, 'build', {
+  runsOn: RunnerLabel.UBUNTU_LATEST,
+  outputs: { artifact_id: `${upload.output('artifactId')}` },
+  steps: [co, setupNodeV6({ id: 'node', with: { nodeVersion: '22' } }), upload],
+});
+```
+
+Define your own typed actions with `defineAction`:
+
+```typescript
+import { defineAction } from '@factbird/cdkactions';
+
+const myAction = defineAction<
+  { environment: { required: true }; dryRun: { default: 'false' } },
+  { deployUrl: {} }
+>('my-org/deploy-action@v1');
+```
+
 ## Features
 
 | Feature | Description | Example |
 |---------|-------------|---------|
 | Matrix builds | Generic `StrategyProps<TMatrix>` with typed `matrix.<key>` access | [01-nodejs-ci-matrix.ts](packages/cdkactions/examples/01-nodejs-ci-matrix.ts) |
+| Docker build & push | Concurrency, permissions, context proxies for credentials | [02-docker-build-push.ts](packages/cdkactions/examples/02-docker-build-push.ts) |
+| Multi-job pipelines | Job dependencies, typed artifact upload/download, conditional deploy | [03-multi-job-pipeline.ts](packages/cdkactions/examples/03-multi-job-pipeline.ts) |
+| Manual dispatch | `workflowDispatch` with typed inputs (choice, boolean, environment) | [05-manual-dispatch.ts](packages/cdkactions/examples/05-manual-dispatch.ts) |
+| Reusable workflows | `workflowCall` with inputs, outputs, and secrets | [06-reusable-workflow.ts](packages/cdkactions/examples/06-reusable-workflow.ts) |
 | Docker services | Container jobs with `command` and `entrypoint` | [07-container-services.ts](packages/cdkactions/examples/07-container-services.ts) |
 | Composite actions | Reusable multi-step actions as constructs | [08-composite-action.ts](packages/cdkactions/examples/08-composite-action.ts) |
-| Typed expressions | `github.*`, `runner.*`, comparison operators, built-in functions | [09-expressions-conditions.ts](packages/cdkactions/examples/09-expressions-conditions.ts) |
+| Typed expressions | Context proxies (`github.*`, `secrets.*`), operators, auto-wrapping | [09-expressions-conditions.ts](packages/cdkactions/examples/09-expressions-conditions.ts) |
+| Cross-workflow deps | Workflow-to-workflow dependencies via `workflow_run` | [10-cross-workflow-deps.ts](packages/cdkactions/examples/10-cross-workflow-deps.ts) |
 | Full permissions | All 16 scopes with restricted subtypes (`idToken: 'write'\|'none'`) | [11-permissions-concurrency.ts](packages/cdkactions/examples/11-permissions-concurrency.ts) |
 | Runner groups | `RunnerGroupConfig`, custom labels, runner registry pattern | [12-multi-platform-runner-groups.ts](packages/cdkactions/examples/12-multi-platform-runner-groups.ts) |
+| Runner registry | Organization-specific runner labels with `RunnerLabel.custom()` | [15-runner-registry.ts](packages/cdkactions/examples/15-runner-registry.ts) |
 | Typed action refs | `Action<TInputs, TOutputs>` with compile-time input/output checks | [16-typed-action-refs.ts](packages/cdkactions/examples/16-typed-action-refs.ts) |
 | Validation | Synth-time checks: step mutual exclusion, cron syntax, matrix size | Built-in via `Node.addValidation()` |
 
 See all 17 examples in [`packages/cdkactions/examples/`](packages/cdkactions/examples/).
-
-## Migration from Previous Version
-
-### Runner labels
-
-```typescript
-// Before
-new Job(workflow, 'build', {
-  runsOn: 'ubuntu-latest',           // bare string — any typo accepted
-  // ...
-});
-
-// After
-new Job(workflow, 'build', {
-  runsOn: RunnerLabel.UBUNTU_LATEST,  // branded type — typos are compile errors
-  // ...
-});
-```
-
-### Steps
-
-```typescript
-// Before — run and uses on the same interface, no mutual exclusion
-const step: StepsProps = {
-  uses: 'actions/checkout@v4',
-  run: 'echo hi',  // no error, but invalid at runtime
-};
-
-// After — discriminated union prevents invalid combinations
-const step: RunStep = { run: 'echo hi' };
-const step: UsesStep = { uses: 'actions/checkout@v4' };
-// { run: '...', uses: '...' } is a compile error
-```
-
-### Permissions
-
-```typescript
-// Before — only contents scope
-{ permissions: { contents: 'write' } }
-
-// After — all 16 scopes, restricted subtypes
-{
-  permissions: {
-    contents: 'write',
-    packages: 'read',
-    idToken: 'write',   // only 'write' | 'none' accepted
-    models: 'read',     // only 'read' | 'none' accepted
-  }
-}
-```
-
-### Strategy
-
-```typescript
-// Before
-{ strategy: { matrix: { os: ['ubuntu-latest'] }, fastFail: true } }
-
-// After — generic TMatrix, typed include/exclude, renamed to match GitHub
-{ strategy: { matrix: { os: ['ubuntu-latest'] as const }, failFast: true } }
-```
 
 ## Contributing
 

--- a/docs/getting-started/typescript.md
+++ b/docs/getting-started/typescript.md
@@ -1,45 +1,132 @@
 # Getting Started (TypeScript)
 
-## Install the CLI
+## Install
 
-The first step to using cdkactions is installing the cdkactions CLI which can be installed using npm or yarn:
-
-``` bash
-npm install -g cdkactions-cli
-yarn global add cdkactions-cli
+```bash
+npm install @factbird/cdkactions constructs
 ```
 
-## Create a New Project
+## Create a workflow
 
-Navigate to the `.github` folder within your git repo and run the following commands:
+Create a file (e.g., `main.ts`) that defines your GitHub Actions workflows:
 
-``` bash
-mkdir -p workflows cdk
-cd cdk
-cdkactions init typescript-app
+```typescript
+import {
+  App, Stack, Workflow, Job, RunnerLabel,
+  checkoutV4, expression, eq, not, and,
+} from '@factbird/cdkactions';
+
+const { github, secrets } = expression;
+
+const app = new App();
+const stack = new Stack(app, 'ci');
+
+const workflow = new Workflow(stack, 'build', {
+  name: 'CI',
+  on: {
+    push: { branches: ['main'] },
+    pullRequest: { branches: ['main'] },
+  },
+});
+
+new Job(workflow, 'test', {
+  runsOn: RunnerLabel.UBUNTU_LATEST,
+  steps: [
+    checkoutV4(),
+    { name: 'Install', run: 'npm ci' },
+    { name: 'Test', run: 'npm test' },
+  ],
+});
+
+app.synth();
 ```
 
-This will:
+Run `npx ts-node main.ts` (or `bun run main.ts`) to produce `.github/workflows/cdkactions_build.yaml`.
 
-* Create a workflows directory if one doesn't already exist
-* Create a cdk directory and add all the required configuration to use cdkactions.
+## Typed expressions
 
-## Use cdkactions
+Context proxies provide autocomplete on all GitHub Actions contexts. Expressions are automatically wrapped in `${{ }}` during synthesis.
 
-The final step is to actually use cdkactions. See the [examples directory](../../examples/typescript/) or the [API guide](../../packages/cdkactions/API.md) for additional information.
+```typescript
+const { github, secrets, env, matrix } = expression;
+
+// Use directly in step config — auto-wrapped during synthesis
+{
+  with: {
+    username: github.actor,        // → ${{ github.actor }}
+    password: secrets.GITHUB_TOKEN, // → ${{ secrets.GITHUB_TOKEN }}
+  },
+}
+
+// Compose with operators
+const isMain = eq(github.ref, 'refs/heads/main');
+const deployCondition = and(isMain, not(eq(github.actor, 'dependabot[bot]')));
+
+// Use in `if` — raw expression without ${{ }} (GitHub auto-evaluates)
+new Job(workflow, 'deploy', {
+  if: deployCondition,
+  // ...
+});
+
+// Template literals — tokens are resolved during synthesis
+{ concurrency: { group: `deploy-${github.ref}` } }
+// → "deploy-${{ github.ref }}"
+```
+
+## Typed action references
+
+Pre-defined actions like `checkoutV4`, `uploadArtifactV4`, and `setupNodeV6` enforce inputs and outputs at compile time.
+
+```typescript
+import { checkoutV4, uploadArtifactV4 } from '@factbird/cdkactions';
+
+// All-optional inputs — parameter is optional
+checkoutV4()
+checkoutV4({ with: { fetchDepth: 0, lfs: true } })
+
+// Required inputs are enforced
+uploadArtifactV4({ id: 'upload', with: { name: 'dist', path: 'dist/' } })
+
+// Typed output access
+const co = checkoutV4({ id: 'co' });
+co.output('commit');  // ✓
+// co.output('foo');  // ✗ compile error
+```
+
+Define your own typed actions:
+
+```typescript
+import { defineAction } from '@factbird/cdkactions';
+
+const myAction = defineAction<
+  { environment: { required: true }; dryRun: { default: 'false' } },
+  { deployUrl: {} }
+>('my-org/deploy-action@v1');
+
+myAction({ id: 'deploy', with: { environment: 'prod' } });
+```
 
 ## Tips & Tricks
 
-When defining a multiline run command for a step inside of a job, a package like [ts-dedent](https://www.npmjs.com/package/ts-dedent) may be useful to strip additional indentation from multiline strings. See the [PyPI Publish example](../../examples/typescript/pypi-publish/) for an example of how to use it.
+When defining a multiline run command for a step, [ts-dedent](https://www.npmjs.com/package/ts-dedent) strips extra indentation from template literals:
 
-## API Reference
+```typescript
+import dedent from 'ts-dedent';
 
-To see a list of all cdkactions constructs and properties see the [API reference](../../packages/cdkactions/API.md)
+{ run: dedent`
+  echo "Step 1"
+  echo "Step 2"
+` }
+```
 
 ## Synthesize manifests
 
-When you make changes to your cdkactions project and want to update the `.yaml` manifests, just run the following command in the `cdk` folder:
+After making changes, regenerate the YAML files:
 
-``` bash
-yarn build
+```bash
+bun run main.ts
 ```
+
+## API Reference
+
+See the [API reference](../../packages/cdkactions/API.md) for all constructs and properties, and the [examples](../../packages/cdkactions/examples/) for complete usage patterns.

--- a/packages/cdkactions/examples/01-nodejs-ci-matrix.ts
+++ b/packages/cdkactions/examples/01-nodejs-ci-matrix.ts
@@ -1,5 +1,7 @@
-import { App, Stack, Workflow, Job, RunnerLabel } from '#@/index.js';
-import { checkoutV4 } from '../src/actions.js';
+import { App, Stack, Workflow, Job, RunnerLabel, expression } from '#@/index.js';
+import { checkoutV4, setupNodeV6 } from '../src/actions.js';
+
+const { matrix } = expression;
 
 export function create(app?: App) {
   const _app = app ?? new App();
@@ -23,11 +25,7 @@ export function create(app?: App) {
     },
     steps: [
       checkoutV4(),
-      {
-        name: 'Setup Node.js',
-        uses: 'actions/setup-node@v4',
-        with: { 'node-version': '${{ matrix.node-version }}' },
-      },
+      setupNodeV6({ id: 'setup-node', with: { nodeVersion: `${matrix.nodeVersion}` } }),
       { name: 'Install', run: 'npm ci' },
       { name: 'Lint', run: 'npm run lint' },
       { name: 'Test', run: 'npm test' },


### PR DESCRIPTION
## Summary

- Replace migration-focused before/after README sections with concise intro sections for typed expressions, context proxies, and typed action references
- Rewrite getting-started guide to reflect current API (`checkoutV4()`, `expression` namespace, `defineAction`)
- Expand features table from 8 to 14 entries covering all major examples
- Update example 01 to use `setupNodeV6` and `matrix` context proxy instead of raw `uses` string

## Test plan

- [x] Verify `bun run build` passes (TypeScript compilation validates example correctness)
- [x] Review rendered README on GitHub for formatting
- [x] Confirm example 01 snapshot update matches expected YAML output