### PR TITLE
fix(release): resolve workspace: protocol before npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Set version from tag
+      - name: Set version from tag and resolve workspace references
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           for pkg in packages/*/package.json; do
@@ -27,6 +27,16 @@ jobs:
               const pkg = JSON.parse(fs.readFileSync('${pkg}', 'utf8'));
               if (!pkg.private) {
                 pkg.version = '${VERSION}';
+                for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
+                  const deps = pkg[depType];
+                  if (!deps) continue;
+                  for (const [name, value] of Object.entries(deps)) {
+                    if (typeof value === 'string' && value.startsWith('workspace:')) {
+                      const range = value.slice('workspace:'.length);
+                      deps[name] = '${VERSION}';
+                    }
+                  }
+                }
                 fs.writeFileSync('${pkg}', JSON.stringify(pkg, null, 2) + '\n');
               }
             "


### PR DESCRIPTION
## Summary
- `npm publish` does not resolve `workspace:` protocol references, so `@factbird/cdkactions-cli@2.0.0` was published with a literal `"workspace:^"` dependency on `@factbird/cdkactions`, breaking `yarn install` for consumers.
- The release workflow now resolves all `workspace:` dependencies to the exact tag version during the version-setting step, before `npm publish` runs.

## Test plan
- [ ] Tag a pre-release (e.g. `v2.0.1-rc.0`) and verify the published package.json has the resolved version instead of `workspace:^`