### PR TITLE
fix(expressions): correct not() operator precedence

### DIFF
--- a/packages/cdkactions/src/expressions.ts
+++ b/packages/cdkactions/src/expressions.ts
@@ -278,7 +278,7 @@ export function lte(left: Expression<number>, right: Expression<number> | number
 
 /** Logical negation: produces `!<expr>`. */
 export function not(e: Expression<boolean>): Expression<boolean> {
-  return expr(`!${unwrapToken(e)}`);
+  return expr(`!(${unwrapToken(e)})`);
 }
 
 /** Produces `contains(<search>, <item>)`. */

--- a/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
+++ b/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
@@ -354,7 +354,7 @@ on:
       - main
 jobs:
   deploy:
-    if: (github.ref == 'refs/heads/main' && !github.actor == 'dependabot[bot]')
+    if: (github.ref == 'refs/heads/main' && !(github.actor == 'dependabot[bot]'))
     runs-on: ubuntu-latest
     steps:
       - name: Deploy

--- a/packages/cdkactions/test/expressions.test.ts
+++ b/packages/cdkactions/test/expressions.test.ts
@@ -148,7 +148,7 @@ test('lte produces correct expression', () => {
 });
 
 test('not produces correct expression', () => {
-  expect(raw(not(github.refProtected))).toBe('!github.ref_protected');
+  expect(raw(not(github.refProtected))).toBe('!(github.ref_protected)');
 });
 
 test('contains produces correct expression', () => {


### PR DESCRIPTION
## Summary
- `not()` prepended `!` without parentheses, causing `not(eq(a, b))` to produce `!a == b` instead of `!(a == b)`
- In GitHub Actions expressions, `!` has higher precedence than `==`, so the old output evaluated as `(!a) == b` — always incorrect
- Now wraps the inner expression in parentheses: `!(expr)`

## Test plan
- [x] Unit test updated and passing
- [x] Snapshot updated to reflect correct output (`!(github.actor == 'dependabot[bot]')`)