### PR TITLE
feat: recursive context proxies for deep property access

### DIFF
--- a/packages/cdkactions/examples/03-multi-job-pipeline.ts
+++ b/packages/cdkactions/examples/03-multi-job-pipeline.ts
@@ -1,7 +1,5 @@
-import { App, Stack, Workflow, Job, RunnerLabel, expression } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, eq } from '#src/index.ts';
 import { checkoutV4, uploadArtifactV4, downloadArtifactV4 } from '#src/actions.ts';
-
-const { eq, github } = expression;
 
 export function create(app?: App) {
   const _app = app ?? new App();
@@ -27,7 +25,7 @@ export function create(app?: App) {
 
   const deploy = new Job(workflow, 'deploy', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
-    if: eq(github.ref, 'refs/heads/main'),
+    if: (github) => eq(github.ref, 'refs/heads/main'),
     environment: 'production',
     steps: [
       downloadArtifactV4({ name: 'Download artifact', with: { name: 'dist' } }),

--- a/packages/cdkactions/examples/08-composite-action.ts
+++ b/packages/cdkactions/examples/08-composite-action.ts
@@ -1,4 +1,4 @@
-import { App, Stack, Workflow, Job, RunnerLabel, Shell, CompositeAction, hashFiles } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, Shell, CompositeAction, hashFiles, steps } from '#src/index.ts';
 
 export function create(app?: App) {
   const _app = app ?? new App();
@@ -12,7 +12,7 @@ export function create(app?: App) {
       registry: { description: 'npm registry URL', required: false, default: 'https://registry.npmjs.org' },
     },
     outputs: {
-      cacheHit: { description: 'Whether cache was hit', value: '${{ steps.cache.outputs.cache-hit }}' },
+      cacheHit: { description: 'Whether cache was hit', value: `${steps.cache.outputs['cache-hit']}` },
     },
     steps: [
       {

--- a/packages/cdkactions/examples/08-composite-action.ts
+++ b/packages/cdkactions/examples/08-composite-action.ts
@@ -18,7 +18,7 @@ export function create(app?: App) {
       registry: { description: 'npm registry URL', required: false, default: 'https://registry.npmjs.org' },
     },
     outputs: {
-      cacheHit: { description: 'Whether cache was hit', value: `${cacheStep.output('cache-hit')}` },
+      cacheHit: { description: 'Whether cache was hit', value: cacheStep.output('cache-hit') },
     },
     steps: [
       cacheStep,

--- a/packages/cdkactions/examples/08-composite-action.ts
+++ b/packages/cdkactions/examples/08-composite-action.ts
@@ -1,8 +1,14 @@
-import { App, Stack, Workflow, Job, RunnerLabel, Shell, CompositeAction, hashFiles, steps } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, Shell, CompositeAction, hashFiles, step } from '#src/index.ts';
 
 export function create(app?: App) {
   const _app = app ?? new App();
   const stack = new Stack(_app, 'composite');
+
+  const cacheStep = step({
+    id: 'cache',
+    uses: 'actions/cache@v4',
+    with: { path: 'node_modules', key: `deps-${hashFiles('package-lock.json')}` },
+  } as const);
 
   const setupAction = new CompositeAction('setup-project', {
     name: 'Setup Project',
@@ -12,14 +18,10 @@ export function create(app?: App) {
       registry: { description: 'npm registry URL', required: false, default: 'https://registry.npmjs.org' },
     },
     outputs: {
-      cacheHit: { description: 'Whether cache was hit', value: `${steps.cache.outputs['cache-hit']}` },
+      cacheHit: { description: 'Whether cache was hit', value: `${cacheStep.output('cache-hit')}` },
     },
     steps: [
-      {
-        id: 'cache',
-        uses: 'actions/cache@v4',
-        with: { path: 'node_modules', key: `deps-${hashFiles('package-lock.json')}` },
-      },
+      cacheStep,
       { name: 'Install', run: 'npm ci', shell: Shell.BASH },
     ],
   } as const);
@@ -34,13 +36,13 @@ export function create(app?: App) {
     steps: [],
   });
 
-  const step = setupAction.asStep(workflow, {
+  const setupStep = setupAction.asStep(workflow, {
     id: 'setup',
     with: { nodeVersion: '20' },
   });
 
   // Verify typed output accessor works
-  const _cacheHit: string = step.output('cacheHit');
+  const _cacheHit: string = setupStep.output('cacheHit');
 
   return _app;
 }

--- a/packages/cdkactions/examples/09-expressions-conditions.ts
+++ b/packages/cdkactions/examples/09-expressions-conditions.ts
@@ -1,6 +1,4 @@
-import { App, Stack, Workflow, Job, RunnerLabel, expression } from '#src/index.ts';
-
-const { github, eq, neq, contains, startsWith, not, and, success, failure, always, cancelled } = expression;
+import { App, Stack, Workflow, Job, RunnerLabel, and, eq, neq, not } from '#src/index.ts';
 
 export function create(app?: App) {
   const _app = app ?? new App();
@@ -11,17 +9,9 @@ export function create(app?: App) {
     on: { push: { branches: ['main'] } },
   });
 
-  const isMain = eq(github.ref, 'refs/heads/main');
-  const isDocChange = contains(github.eventName, 'docs/');
-  const isNotFork = not(eq(github.eventName, 'pull_request_target'));
-  const runOnFailure = failure();
-  const runAlways = always();
-
-  const deployCondition = and(isMain, not(eq(github.actor, 'dependabot[bot]')));
-
   new Job(workflow, 'deploy', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
-    if: deployCondition,
+    if: (github) => and(eq(github.ref, 'refs/heads/main'), neq(github.actor, 'dependabot[bot]')),
     steps: [{ name: 'Deploy', run: 'echo deploying' }],
   });
 

--- a/packages/cdkactions/examples/10-cross-workflow-deps.ts
+++ b/packages/cdkactions/examples/10-cross-workflow-deps.ts
@@ -1,4 +1,4 @@
-import { App, Stack, Workflow, Job, RunnerLabel } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, eq } from '#src/index.ts';
 
 export function create(app?: App) {
   const _app = app ?? new App();
@@ -16,12 +16,13 @@ export function create(app?: App) {
 
   const deploy = new Workflow(stack, 'deploy', {
     name: 'Deploy',
-    on: { push: { branches: ['main'] } },
+    on: { workflowRun: { types: ['completed'] } },
   });
   deploy.addDependency(ci);
 
   new Job(deploy, 'deploy', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
+    if: (github) => eq(github.event.workflowRun.conclusion, 'success'),
     steps: [{ name: 'Deploy', run: 'echo deploying' }],
   });
 

--- a/packages/cdkactions/examples/13-github-pages.ts
+++ b/packages/cdkactions/examples/13-github-pages.ts
@@ -1,4 +1,4 @@
-import { App, Stack, Workflow, Job, RunnerLabel, steps } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, step } from '#src/index.ts';
 import { checkoutV4 } from '#src/actions.ts';
 
 export function create(app?: App) {
@@ -28,10 +28,12 @@ export function create(app?: App) {
     ],
   });
 
+  const deploymentStep = step({ id: 'deployment', uses: 'actions/deploy-pages@v4' });
+
   const deploy = new Job(workflow, 'deploy', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
-    environment: { name: 'github-pages', url: `${steps.deployment.outputs.page_url}` },
-    steps: [{ id: 'deployment', uses: 'actions/deploy-pages@v4' }],
+    environment: { name: 'github-pages', url: `${deploymentStep.output('page_url')}` },
+    steps: [deploymentStep],
   });
   deploy.addDependency(build);
 

--- a/packages/cdkactions/examples/13-github-pages.ts
+++ b/packages/cdkactions/examples/13-github-pages.ts
@@ -32,7 +32,7 @@ export function create(app?: App) {
 
   const deploy = new Job(workflow, 'deploy', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
-    environment: { name: 'github-pages', url: `${deploymentStep.output('page_url')}` },
+    environment: { name: 'github-pages', url: deploymentStep.output('page_url') },
     steps: [deploymentStep],
   });
   deploy.addDependency(build);

--- a/packages/cdkactions/examples/13-github-pages.ts
+++ b/packages/cdkactions/examples/13-github-pages.ts
@@ -1,4 +1,4 @@
-import { App, Stack, Workflow, Job, RunnerLabel } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, steps } from '#src/index.ts';
 import { checkoutV4 } from '#src/actions.ts';
 
 export function create(app?: App) {
@@ -30,7 +30,7 @@ export function create(app?: App) {
 
   const deploy = new Job(workflow, 'deploy', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
-    environment: { name: 'github-pages', url: '${{ steps.deployment.outputs.page_url }}' },
+    environment: { name: 'github-pages', url: `${steps.deployment.outputs.page_url}` },
     steps: [{ id: 'deployment', uses: 'actions/deploy-pages@v4' }],
   });
   deploy.addDependency(build);

--- a/packages/cdkactions/src/action.ts
+++ b/packages/cdkactions/src/action.ts
@@ -1,4 +1,4 @@
-import { expr, type Expression } from '#src/expressions.ts';
+import { expr, type Expression, type AnyExpression } from '#src/expressions.ts';
 import type { UsesStep, StepBase } from '#src/job.ts';
 import { camelToKebab } from '#src/utils.ts';
 
@@ -19,10 +19,12 @@ type OptionalInputKeys<T extends ActionInputs> = {
   [K in keyof T & string]: T[K] extends { required: true } ? never : T[K] extends { default: string } ? K : never;
 }[keyof T & string];
 
+type ActionInputValue = string | number | boolean | AnyExpression;
+
 type ActionWith<T extends ActionInputs> = {
-  readonly [K in RequiredInputKeys<T>]: string | number | boolean;
+  readonly [K in RequiredInputKeys<T>]: ActionInputValue;
 } & {
-  readonly [K in OptionalInputKeys<T>]?: string | number | boolean;
+  readonly [K in OptionalInputKeys<T>]?: ActionInputValue;
 };
 
 type ActionCallOptions<TInputs extends ActionInputs, TOutputs extends ActionOutputs> = ([

--- a/packages/cdkactions/src/composite-action.ts
+++ b/packages/cdkactions/src/composite-action.ts
@@ -1,6 +1,6 @@
 import type { Construct } from 'constructs';
 
-import { expr, type Expression } from '#src/expressions.ts';
+import { expr, type AnyExpression } from '#src/expressions.ts';
 import type { StepConfig, UsesStep } from '#src/job.ts';
 import { Stack } from '#src/stack.ts';
 import type { StringMap } from '#src/types.ts';
@@ -95,7 +95,7 @@ type AsStepOptions<
 > = {
   env?: StringMap;
   name?: string;
-  if?: Expression<boolean>;
+  if?: AnyExpression<boolean>;
 } & ([keyof TOutputs] extends [never] ? { id?: string } : { id: string }) &
   ([RequiredInputKeys<T>] extends [never] ? { with?: CompositeActionWith<T> } : { with: CompositeActionWith<T> });
 

--- a/packages/cdkactions/src/expressions.ts
+++ b/packages/cdkactions/src/expressions.ts
@@ -241,6 +241,94 @@ export interface StrategyContext {
   readonly maxParallel: Expression<number>;
 }
 
+// --- Event payload types ---
+// Describe what github.event contains at runtime for each trigger type.
+// All extend Record<string, any> for access to unlisted properties.
+
+export interface PullRequestEventPayload extends Record<string, any> {
+  readonly pull_request: {
+    readonly draft: boolean;
+    readonly title: string;
+    readonly body: string | null;
+    readonly number: number;
+    readonly merged: boolean;
+    readonly head: { readonly ref: string; readonly sha: string; [key: string]: any };
+    readonly base: { readonly ref: string; readonly sha: string; [key: string]: any };
+    [key: string]: any;
+  };
+}
+
+export interface IssueCommentEventPayload extends Record<string, any> {
+  readonly comment: { readonly body: string; readonly id: number; [key: string]: any };
+  readonly issue: { readonly title: string; readonly body: string | null; readonly number: number; [key: string]: any };
+}
+
+export interface PullRequestReviewEventPayload extends Record<string, any> {
+  readonly review: { readonly body: string | null; readonly state: string; [key: string]: any };
+  readonly pull_request: PullRequestEventPayload['pull_request'];
+}
+
+export interface PullRequestReviewCommentEventPayload extends Record<string, any> {
+  readonly comment: { readonly body: string; [key: string]: any };
+  readonly pull_request: PullRequestEventPayload['pull_request'];
+}
+
+export interface IssuesEventPayload extends Record<string, any> {
+  readonly issue: { readonly title: string; readonly body: string | null; readonly number: number; [key: string]: any };
+}
+
+export interface ReleaseEventPayload extends Record<string, any> {
+  readonly release: { readonly tag_name: string; readonly body: string | null; readonly name: string | null; [key: string]: any };
+}
+
+export interface WorkflowRunEventPayload extends Record<string, any> {
+  readonly workflow_run: {
+    readonly conclusion: string | null;
+    readonly name: string;
+    readonly head_branch: string;
+    [key: string]: any;
+  };
+}
+
+export interface PushEventPayload extends Record<string, any> {
+  readonly ref: string;
+  readonly before: string;
+  readonly after: string;
+  readonly commits: Array<{ readonly id: string; readonly message: string; [key: string]: any }>;
+}
+
+interface EventPayloadMap {
+  pullRequest: PullRequestEventPayload;
+  pullRequestTarget: PullRequestEventPayload;
+  pullRequestReview: PullRequestReviewEventPayload;
+  pullRequestReviewComment: PullRequestReviewCommentEventPayload;
+  issueComment: IssueCommentEventPayload;
+  issues: IssuesEventPayload;
+  release: ReleaseEventPayload;
+  workflowRun: WorkflowRunEventPayload;
+  push: PushEventPayload;
+}
+
+/**
+ * Infers the event payload type from the workflow's `on` configuration.
+ * Produces a union of matching payload types for multi-event triggers,
+ * or Record<string, any> for unmapped events.
+ */
+export type InferEventPayload<TOn> = TOn extends string | string[]
+  ? Record<string, any>
+  : TOn extends object
+    ? keyof TOn & keyof EventPayloadMap extends never
+      ? Record<string, any>
+      : EventPayloadMap[keyof TOn & keyof EventPayloadMap]
+    : Record<string, any>;
+
+/**
+ * A GitHubContext with `event` narrowed based on the workflow's trigger configuration.
+ */
+export type GitHubContextFor<TOn> = Omit<GitHubContext, 'event'> & {
+  readonly event: DeepExpression<InferEventPayload<TOn>>;
+};
+
 /** GitHub context — properties of the workflow run and triggering event. */
 export const github: GitHubContext = createContextProxy<GitHubContext>('github', true);
 

--- a/packages/cdkactions/src/expressions.ts
+++ b/packages/cdkactions/src/expressions.ts
@@ -29,13 +29,24 @@ export type Expression<T = unknown> = string & {
   readonly [ExpressionBrand]: T;
 };
 
+/**
+ * A recursive expression type that allows deep property access on object-typed
+ * expressions. For example, `DeepExpression<{ result: string }>` allows `.result`
+ * access, returning `DeepExpression<string>` (which is just `Expression<string>`).
+ */
+export type DeepExpression<T> = Expression<T> &
+  (T extends Record<string, any> ? { readonly [K in keyof T]: DeepExpression<T[K]> } : {});
+
 const TOKEN_BEGIN = '\uFDD0';
 const TOKEN_END = '\uFDD1';
 const TOKEN_REGEX = new RegExp(`${TOKEN_BEGIN}([^${TOKEN_END}]*)${TOKEN_END}`, 'g');
 
+const CONTEXT_PROXY_MARKER = Symbol('cdkactions.contextProxy');
+
 /** Extract the raw expression text from a token-delimited string. */
 export function unwrapToken(value: string): string {
-  return value.replaceAll(TOKEN_BEGIN, '').replaceAll(TOKEN_END, '');
+  const str = typeof value === 'string' ? value : String(value);
+  return str.replaceAll(TOKEN_BEGIN, '').replaceAll(TOKEN_END, '');
 }
 
 /** Create an Expression from a raw string, encoded with token delimiters. */
@@ -44,7 +55,9 @@ export function expr<T = unknown>(value: string): Expression<T> {
 }
 
 export function isExpression(value: unknown): value is Expression {
-  return typeof value === 'string' && value.includes(TOKEN_BEGIN);
+  if (typeof value === 'string') return value.includes(TOKEN_BEGIN);
+  if (value !== null && typeof value === 'object' && CONTEXT_PROXY_MARKER in value) return true;
+  return false;
 }
 
 /**
@@ -58,6 +71,9 @@ export function resolveTokens(obj: unknown): unknown {
   if (typeof obj === 'string') {
     return resolveStringTokens(obj);
   }
+  if (isExpression(obj)) {
+    return resolveStringTokens(String(obj));
+  }
   if (Array.isArray(obj)) {
     return obj.map((item) => resolveTokens(item));
   }
@@ -65,7 +81,9 @@ export function resolveTokens(obj: unknown): unknown {
     return Object.fromEntries(
       Object.entries(obj).map(([key, value]) => {
         if (key === 'if') {
-          return [key, typeof value === 'string' ? unwrapToken(value) : resolveTokens(value)];
+          if (typeof value === 'string') return [key, unwrapToken(value)];
+          if (isExpression(value)) return [key, unwrapToken(String(value))];
+          return [key, resolveTokens(value)];
         }
         return [key, resolveTokens(value)];
       }),
@@ -90,10 +108,26 @@ function resolveStringTokens(value: string): string {
  * preserve the original key.
  */
 function createContextProxy<T extends object>(contextName: string, rename = false): T {
+  const token = expr(contextName);
+
   return new Proxy({} as T, {
-    get(_target, prop: string) {
+    get(_target, prop: string | symbol): unknown {
+      if (prop === CONTEXT_PROXY_MARKER) return true;
+      if (prop === Symbol.toPrimitive) return () => token;
+      if (prop === Symbol.iterator) return token[Symbol.iterator].bind(token);
+      if (typeof prop === 'symbol') return undefined;
+
+      if (prop in String.prototype || prop === 'length') {
+        const val = (token as any)[prop];
+        return typeof val === 'function' ? val.bind(token) : val;
+      }
+
       const key = rename ? camelToSnake(prop) : prop;
-      return expr(`${contextName}.${key}`);
+      return createContextProxy(`${contextName}.${key}`, false);
+    },
+    has(_target, prop) {
+      if (prop === CONTEXT_PROXY_MARKER) return true;
+      return false;
     },
   });
 }
@@ -108,7 +142,7 @@ export interface GitHubContext {
   readonly actorId: Expression<string>;
   readonly apiUrl: Expression<string>;
   readonly baseRef: Expression<string>;
-  readonly event: Expression<object>;
+  readonly event: DeepExpression<Record<string, any>>;
   readonly eventName: Expression<string>;
   readonly graphqlUrl: Expression<string>;
   readonly headRef: Expression<string>;
@@ -166,7 +200,7 @@ export interface MatrixContext {
 
 export interface NeedsContext {
   /** Access a dependent job's context by job ID. */
-  readonly [key: string]: Expression<{
+  readonly [key: string]: DeepExpression<{
     readonly outputs: Record<string, string>;
     readonly result: string;
   }>;
@@ -174,7 +208,7 @@ export interface NeedsContext {
 
 export interface StepsContext {
   /** Access a step's context by step ID. */
-  readonly [key: string]: Expression<{
+  readonly [key: string]: DeepExpression<{
     readonly outputs: Record<string, string>;
     readonly outcome: string;
     readonly conclusion: string;
@@ -192,11 +226,11 @@ export interface VarsContext {
 }
 
 export interface JobContext {
-  readonly container: Expression<{
+  readonly container: DeepExpression<{
     readonly id: string;
     readonly network: string;
   }>;
-  readonly services: Expression<Record<string, { id: string; network: string; ports: Record<string, string> }>>;
+  readonly services: DeepExpression<Record<string, { id: string; network: string; ports: Record<string, string> }>>;
   readonly status: Expression<string>;
 }
 

--- a/packages/cdkactions/src/expressions.ts
+++ b/packages/cdkactions/src/expressions.ts
@@ -25,16 +25,27 @@ declare const ExpressionBrand: unique symbol;
  * (string, boolean, number, object), enabling operators to be constrained
  * at the type level.
  */
-export type Expression<T = unknown> = string & {
-  readonly [ExpressionBrand]: T;
-};
+/**
+ * Minimal branded type that both `Expression<T>` and `DeepExpression<T>` extend.
+ * Used as the parameter type for expression functions — accepts any expression form.
+ */
+export type AnyExpression<T = unknown> = { readonly [ExpressionBrand]: T };
+
+export type Expression<T = unknown> = string & AnyExpression<T>;
 
 /**
- * A recursive expression type that allows deep property access on object-typed
- * expressions. For example, `DeepExpression<{ result: string }>` allows `.result`
- * access, returning `DeepExpression<string>` (which is just `Expression<string>`).
+ * A recursive expression type for context proxy nodes.
+ * Unlike `Expression<T>`, this does NOT extend `string` — context proxies
+ * are not real strings and should not expose `String.prototype` methods.
+ *
+ * For object-typed `T`, deep property access is supported:
+ * `DeepExpression<{ result: string }>` allows `.result` access,
+ * returning `DeepExpression<string>`.
+ *
+ * Both `Expression<T>` and `DeepExpression<T>` share the same brand,
+ * so `Expression<T>` is assignable to `DeepExpression<T>` (for leaf types).
  */
-export type DeepExpression<T> = Expression<T> &
+export type DeepExpression<T> = AnyExpression<T> &
   (T extends Record<string, any> ? { readonly [K in keyof T]: DeepExpression<T[K]> } : {});
 
 const TOKEN_BEGIN = '\uFDD0';
@@ -44,7 +55,7 @@ const TOKEN_REGEX = new RegExp(`${TOKEN_BEGIN}([^${TOKEN_END}]*)${TOKEN_END}`, '
 const CONTEXT_PROXY_MARKER = Symbol('cdkactions.contextProxy');
 
 /** Extract the raw expression text from a token-delimited string. */
-export function unwrapToken(value: string): string {
+export function unwrapToken(value: string | AnyExpression): string {
   const str = typeof value === 'string' ? value : String(value);
   return str.replaceAll(TOKEN_BEGIN, '').replaceAll(TOKEN_END, '');
 }
@@ -54,7 +65,7 @@ export function expr<T = unknown>(value: string): Expression<T> {
   return `${TOKEN_BEGIN}${value}${TOKEN_END}` as Expression<T>;
 }
 
-export function isExpression(value: unknown): value is Expression {
+export function isExpression(value: unknown): value is AnyExpression {
   if (typeof value === 'string') return value.includes(TOKEN_BEGIN);
   if (value !== null && typeof value === 'object' && CONTEXT_PROXY_MARKER in value) return true;
   return false;
@@ -133,69 +144,69 @@ function createContextProxy<T extends object>(contextName: string, rename = fals
 }
 
 export interface GitHubContext {
-  readonly action: Expression<string>;
-  readonly actionPath: Expression<string>;
-  readonly actionRef: Expression<string>;
-  readonly actionRepository: Expression<string>;
-  readonly actionStatus: Expression<string>;
-  readonly actor: Expression<string>;
-  readonly actorId: Expression<string>;
-  readonly apiUrl: Expression<string>;
-  readonly baseRef: Expression<string>;
+  readonly action: DeepExpression<string>;
+  readonly actionPath: DeepExpression<string>;
+  readonly actionRef: DeepExpression<string>;
+  readonly actionRepository: DeepExpression<string>;
+  readonly actionStatus: DeepExpression<string>;
+  readonly actor: DeepExpression<string>;
+  readonly actorId: DeepExpression<string>;
+  readonly apiUrl: DeepExpression<string>;
+  readonly baseRef: DeepExpression<string>;
   readonly event: DeepExpression<Record<string, any>>;
-  readonly eventName: Expression<string>;
-  readonly graphqlUrl: Expression<string>;
-  readonly headRef: Expression<string>;
-  readonly job: Expression<string>;
-  readonly path: Expression<string>;
-  readonly ref: Expression<string>;
-  readonly refName: Expression<string>;
-  readonly refProtected: Expression<boolean>;
-  readonly refType: Expression<'branch' | 'tag'>;
-  readonly repository: Expression<string>;
-  readonly repositoryId: Expression<string>;
-  readonly repositoryOwner: Expression<string>;
-  readonly repositoryOwnerId: Expression<string>;
-  readonly repositoryUrl: Expression<string>;
-  readonly retentionDays: Expression<string>;
-  readonly runId: Expression<string>;
-  readonly runNumber: Expression<string>;
-  readonly runAttempt: Expression<string>;
-  readonly secretSource: Expression<string>;
-  readonly serverUrl: Expression<string>;
-  readonly sha: Expression<string>;
-  readonly token: Expression<string>;
-  readonly triggeringActor: Expression<string>;
-  readonly workflow: Expression<string>;
-  readonly workflowRef: Expression<string>;
-  readonly workflowSha: Expression<string>;
-  readonly workspace: Expression<string>;
+  readonly eventName: DeepExpression<string>;
+  readonly graphqlUrl: DeepExpression<string>;
+  readonly headRef: DeepExpression<string>;
+  readonly job: DeepExpression<string>;
+  readonly path: DeepExpression<string>;
+  readonly ref: DeepExpression<string>;
+  readonly refName: DeepExpression<string>;
+  readonly refProtected: DeepExpression<boolean>;
+  readonly refType: DeepExpression<'branch' | 'tag'>;
+  readonly repository: DeepExpression<string>;
+  readonly repositoryId: DeepExpression<string>;
+  readonly repositoryOwner: DeepExpression<string>;
+  readonly repositoryOwnerId: DeepExpression<string>;
+  readonly repositoryUrl: DeepExpression<string>;
+  readonly retentionDays: DeepExpression<string>;
+  readonly runId: DeepExpression<string>;
+  readonly runNumber: DeepExpression<string>;
+  readonly runAttempt: DeepExpression<string>;
+  readonly secretSource: DeepExpression<string>;
+  readonly serverUrl: DeepExpression<string>;
+  readonly sha: DeepExpression<string>;
+  readonly token: DeepExpression<string>;
+  readonly triggeringActor: DeepExpression<string>;
+  readonly workflow: DeepExpression<string>;
+  readonly workflowRef: DeepExpression<string>;
+  readonly workflowSha: DeepExpression<string>;
+  readonly workspace: DeepExpression<string>;
 }
 
 export interface RunnerContext {
-  readonly name: Expression<string>;
-  readonly os: Expression<string>;
-  readonly arch: Expression<string>;
-  readonly temp: Expression<string>;
-  readonly toolCache: Expression<string>;
-  readonly debug: Expression<string>;
-  readonly environment: Expression<string>;
+  readonly name: DeepExpression<string>;
+  readonly os: DeepExpression<string>;
+  readonly arch: DeepExpression<string>;
+  readonly temp: DeepExpression<string>;
+  readonly toolCache: DeepExpression<string>;
+  readonly debug: DeepExpression<string>;
+  readonly environment: DeepExpression<string>;
 }
 
 export interface EnvContext {
   /** Access an environment variable by name. */
-  readonly [key: string]: Expression<string>;
+  readonly [key: string]: DeepExpression<string>;
 }
 
 export interface SecretsContext {
-  readonly GITHUB_TOKEN: Expression<string>;
+  readonly GITHUB_TOKEN: DeepExpression<string>;
   /** Access a secret by name. */
-  readonly [key: string]: Expression<string>;
+  readonly [key: string]: DeepExpression<string>;
 }
 
 export interface MatrixContext {
   /** Access a matrix variable by name. */
-  readonly [key: string]: Expression<unknown>;
+  readonly [key: string]: DeepExpression<unknown>;
 }
 
 export interface NeedsContext {
@@ -217,12 +228,12 @@ export interface StepsContext {
 
 export interface InputsContext {
   /** Access a workflow input by name. */
-  readonly [key: string]: Expression<unknown>;
+  readonly [key: string]: DeepExpression<string>;
 }
 
 export interface VarsContext {
   /** Access a configuration variable by name. */
-  readonly [key: string]: Expression<string>;
+  readonly [key: string]: DeepExpression<string>;
 }
 
 export interface JobContext {
@@ -231,14 +242,14 @@ export interface JobContext {
     readonly network: string;
   }>;
   readonly services: DeepExpression<Record<string, { id: string; network: string; ports: Record<string, string> }>>;
-  readonly status: Expression<string>;
+  readonly status: DeepExpression<string>;
 }
 
 export interface StrategyContext {
-  readonly failFast: Expression<boolean>;
-  readonly jobIndex: Expression<number>;
-  readonly jobTotal: Expression<number>;
-  readonly maxParallel: Expression<number>;
+  readonly failFast: DeepExpression<boolean>;
+  readonly jobIndex: DeepExpression<number>;
+  readonly jobTotal: DeepExpression<number>;
+  readonly maxParallel: DeepExpression<number>;
 }
 
 // --- Event payload types ---
@@ -278,7 +289,12 @@ export interface IssuesEventPayload extends Record<string, any> {
 }
 
 export interface ReleaseEventPayload extends Record<string, any> {
-  readonly release: { readonly tagName: string; readonly body: string | null; readonly name: string | null; [key: string]: any };
+  readonly release: {
+    readonly tagName: string;
+    readonly body: string | null;
+    readonly name: string | null;
+    [key: string]: any;
+  };
 }
 
 export interface WorkflowRunEventPayload extends Record<string, any> {
@@ -369,66 +385,66 @@ function formatOperand(value: unknown): string {
 }
 
 /** Equality: produces `<left> == <right>`. */
-export function eq<T>(left: Expression<T>, right: Expression<T> | T): Expression<boolean> {
+export function eq<T>(left: AnyExpression<T>, right: AnyExpression<T> | T): Expression<boolean> {
   return expr(`${unwrapToken(left)} == ${formatOperand(right)}`);
 }
 
 /** Inequality: produces `<left> != <right>`. */
-export function neq<T>(left: Expression<T>, right: Expression<T> | T): Expression<boolean> {
+export function neq<T>(left: AnyExpression<T>, right: AnyExpression<T> | T): Expression<boolean> {
   return expr(`${unwrapToken(left)} != ${formatOperand(right)}`);
 }
 
 /** Greater than: produces `<left> > <right>`. */
-export function gt(left: Expression<number>, right: Expression<number> | number): Expression<boolean> {
+export function gt(left: AnyExpression<number>, right: AnyExpression<number> | number): Expression<boolean> {
   return expr(`${unwrapToken(left)} > ${formatOperand(right)}`);
 }
 
 /** Greater than or equal: produces `<left> >= <right>`. */
-export function gte(left: Expression<number>, right: Expression<number> | number): Expression<boolean> {
+export function gte(left: AnyExpression<number>, right: AnyExpression<number> | number): Expression<boolean> {
   return expr(`${unwrapToken(left)} >= ${formatOperand(right)}`);
 }
 
 /** Less than: produces `<left> < <right>`. */
-export function lt(left: Expression<number>, right: Expression<number> | number): Expression<boolean> {
+export function lt(left: AnyExpression<number>, right: AnyExpression<number> | number): Expression<boolean> {
   return expr(`${unwrapToken(left)} < ${formatOperand(right)}`);
 }
 
 /** Less than or equal: produces `<left> <= <right>`. */
-export function lte(left: Expression<number>, right: Expression<number> | number): Expression<boolean> {
+export function lte(left: AnyExpression<number>, right: AnyExpression<number> | number): Expression<boolean> {
   return expr(`${unwrapToken(left)} <= ${formatOperand(right)}`);
 }
 
-/** Logical negation: produces `!<expr>`. */
-export function not(e: Expression<boolean>): Expression<boolean> {
+/** Logical negation: produces `!(expr)`. */
+export function not(e: AnyExpression<boolean>): Expression<boolean> {
   return expr(`!(${unwrapToken(e)})`);
 }
 
 /** Produces `contains(<search>, <item>)`. */
 export function contains(
-  search: Expression<string> | Expression<string[]>,
-  item: string | Expression<string>,
+  search: AnyExpression<string> | AnyExpression<string[]>,
+  item: string | AnyExpression<string>,
 ): Expression<boolean> {
   return expr(`contains(${unwrapToken(search)}, ${formatOperand(item)})`);
 }
 
 /** Produces `startsWith(<str>, <value>)`. */
-export function startsWith(str: Expression<string>, value: string | Expression<string>): Expression<boolean> {
+export function startsWith(str: AnyExpression<string>, value: string | AnyExpression<string>): Expression<boolean> {
   return expr(`startsWith(${unwrapToken(str)}, ${formatOperand(value)})`);
 }
 
 /** Produces `endsWith(<str>, <value>)`. */
-export function endsWith(str: Expression<string>, value: string | Expression<string>): Expression<boolean> {
+export function endsWith(str: AnyExpression<string>, value: string | AnyExpression<string>): Expression<boolean> {
   return expr(`endsWith(${unwrapToken(str)}, ${formatOperand(value)})`);
 }
 
 /** Produces `format(<template>, <args...>)`. */
-export function format(template: string, ...args: Array<string | Expression>): Expression<string> {
+export function format(template: string, ...args: Array<string | AnyExpression>): Expression<string> {
   const allArgs = [`'${template}'`, ...args.map((a) => formatOperand(a))];
   return expr(`format(${allArgs.join(', ')})`);
 }
 
 /** Produces `join(<array>, <separator>)`. */
-export function join(array: Expression<string[]>, separator?: string): Expression<string> {
+export function join(array: AnyExpression<string[]>, separator?: string): Expression<string> {
   if (separator !== undefined) {
     return expr(`join(${unwrapToken(array)}, '${separator}')`);
   }
@@ -436,12 +452,12 @@ export function join(array: Expression<string[]>, separator?: string): Expressio
 }
 
 /** Produces `toJSON(<value>)`. */
-export function toJSON(value: Expression): Expression<string> {
+export function toJSON(value: AnyExpression): Expression<string> {
   return expr(`toJSON(${unwrapToken(value)})`);
 }
 
 /** Produces `fromJSON(<value>)`. */
-export function fromJSON<T = unknown>(value: Expression<string>): Expression<T> {
+export function fromJSON<T = unknown>(value: AnyExpression<string>): Expression<T> {
   return expr(`fromJSON(${unwrapToken(value)})`);
 }
 
@@ -472,7 +488,7 @@ export function cancelled(): Expression<boolean> {
 }
 
 /** Logical AND: produces `(<a> && <b> && ...)`. */
-export function and(...exprs: Expression<boolean>[]): Expression<boolean> {
+export function and(...exprs: AnyExpression<boolean>[]): Expression<boolean> {
   const parts = exprs.map((e) => unwrapToken(e)).filter((s) => s.trim() !== '');
   if (parts.length === 0) return expr('');
   if (parts.length === 1) return expr(parts[0]);
@@ -480,7 +496,7 @@ export function and(...exprs: Expression<boolean>[]): Expression<boolean> {
 }
 
 /** Logical OR: produces `(<a> || <b> || ...)`. */
-export function or(...exprs: Expression<boolean>[]): Expression<boolean> {
+export function or(...exprs: AnyExpression<boolean>[]): Expression<boolean> {
   const parts = exprs.map((e) => unwrapToken(e)).filter((s) => s.trim() !== '');
   if (parts.length === 0) return expr('');
   if (parts.length === 1) return expr(parts[0]);

--- a/packages/cdkactions/src/expressions.ts
+++ b/packages/cdkactions/src/expressions.ts
@@ -123,7 +123,7 @@ function createContextProxy<T extends object>(contextName: string, rename = fals
       }
 
       const key = rename ? camelToSnake(prop) : prop;
-      return createContextProxy(`${contextName}.${key}`, false);
+      return createContextProxy(`${contextName}.${key}`, rename);
     },
     has(_target, prop) {
       if (prop === CONTEXT_PROXY_MARKER) return true;
@@ -246,7 +246,7 @@ export interface StrategyContext {
 // All extend Record<string, any> for access to unlisted properties.
 
 export interface PullRequestEventPayload extends Record<string, any> {
-  readonly pull_request: {
+  readonly pullRequest: {
     readonly draft: boolean;
     readonly title: string;
     readonly body: string | null;
@@ -265,12 +265,12 @@ export interface IssueCommentEventPayload extends Record<string, any> {
 
 export interface PullRequestReviewEventPayload extends Record<string, any> {
   readonly review: { readonly body: string | null; readonly state: string; [key: string]: any };
-  readonly pull_request: PullRequestEventPayload['pull_request'];
+  readonly pullRequest: PullRequestEventPayload['pullRequest'];
 }
 
 export interface PullRequestReviewCommentEventPayload extends Record<string, any> {
   readonly comment: { readonly body: string; [key: string]: any };
-  readonly pull_request: PullRequestEventPayload['pull_request'];
+  readonly pullRequest: PullRequestEventPayload['pullRequest'];
 }
 
 export interface IssuesEventPayload extends Record<string, any> {
@@ -278,14 +278,14 @@ export interface IssuesEventPayload extends Record<string, any> {
 }
 
 export interface ReleaseEventPayload extends Record<string, any> {
-  readonly release: { readonly tag_name: string; readonly body: string | null; readonly name: string | null; [key: string]: any };
+  readonly release: { readonly tagName: string; readonly body: string | null; readonly name: string | null; [key: string]: any };
 }
 
 export interface WorkflowRunEventPayload extends Record<string, any> {
-  readonly workflow_run: {
+  readonly workflowRun: {
     readonly conclusion: string | null;
     readonly name: string;
-    readonly head_branch: string;
+    readonly headBranch: string;
     [key: string]: any;
   };
 }

--- a/packages/cdkactions/src/job.ts
+++ b/packages/cdkactions/src/job.ts
@@ -1,6 +1,6 @@
 import { Construct } from 'constructs';
 
-import { and, expr, type Expression, github, type GitHubContextFor } from '#src/expressions.ts';
+import { and, expr, type Expression, type AnyExpression, github, type GitHubContextFor } from '#src/expressions.ts';
 import type { RunnerLabel, Shell } from '#src/nominal.ts';
 import type { DefaultsProps, StringMap } from '#src/types.ts';
 import { renameKeys, type Writable } from '#src/utils.ts';
@@ -41,7 +41,9 @@ export interface RunnerGroupConfig {
   readonly labels?: RunnerLabel[];
 }
 
-export type IfCondition<TOn = unknown> = Expression<boolean> | ((github: GitHubContextFor<TOn>) => Expression<boolean>);
+export type IfCondition<TOn = unknown> =
+  | AnyExpression<boolean>
+  | ((github: GitHubContextFor<TOn>) => Expression<boolean>);
 
 export interface StepBase<TOn = unknown> {
   readonly id?: string;
@@ -121,16 +123,19 @@ export function createMatrixProxy<TMatrix extends MatrixDefinition>(_matrix: TMa
 /**
  * Configuration for a single GitHub Action job.
  */
-export interface JobProps<TMatrix extends MatrixDefinition = MatrixDefinition, TOn extends WorkflowTrigger = WorkflowTrigger> {
+export interface JobProps<
+  TMatrix extends MatrixDefinition = MatrixDefinition,
+  TOn extends WorkflowTrigger = WorkflowTrigger,
+> {
   readonly name?: string;
   readonly needs?: string | string[];
-  readonly runsOn?: RunnerLabel | RunnerLabel[] | RunnerGroupConfig | Expression<string>;
+  readonly runsOn?: RunnerLabel | RunnerLabel[] | RunnerGroupConfig | AnyExpression<string>;
   readonly outputs?: StringMap;
   readonly env?: StringMap;
   readonly defaults?: DefaultsProps;
   readonly if?: IfCondition<TOn>;
   readonly steps?: StepConfig<TOn>[];
-  readonly secrets?: Record<string, string | Expression<string>> | 'inherit';
+  readonly secrets?: Record<string, string | AnyExpression<string>> | 'inherit';
   readonly timeoutMinutes?: number;
   readonly strategy?: StrategyProps<TMatrix>;
   readonly continueOnError?: boolean;
@@ -146,10 +151,13 @@ export interface JobProps<TMatrix extends MatrixDefinition = MatrixDefinition, T
 /**
  * Represents a GH Actions job.
  */
-export class Job<TMatrix extends MatrixDefinition = MatrixDefinition, TOn extends WorkflowTrigger = WorkflowTrigger> extends Construct {
+export class Job<
+  TMatrix extends MatrixDefinition = MatrixDefinition,
+  TOn extends WorkflowTrigger = WorkflowTrigger,
+> extends Construct {
   protected readonly action: Writable<JobProps<TMatrix, TOn>>;
   public readonly id: string;
-  public if?: Expression<boolean>;
+  public if?: AnyExpression<boolean>;
   public readonly matrix: MatrixProxy<TMatrix>;
 
   public constructor(scope: Workflow<TOn>, id: string, config: JobProps<TMatrix, TOn>) {
@@ -189,7 +197,7 @@ export class Job<TMatrix extends MatrixDefinition = MatrixDefinition, TOn extend
     const { uses, runsOn, steps, strategy, if: propsIf, ...rest } = this.action;
 
     const resolvedIf = typeof propsIf === 'function' ? propsIf(github as any) : propsIf;
-    const conditions = [this.if, resolvedIf].filter((c): c is Expression<boolean> => c !== undefined);
+    const conditions = [this.if, resolvedIf].filter((c): c is AnyExpression<boolean> => c !== undefined);
     const _if = conditions.length > 0 ? and(...conditions) : undefined;
 
     let serializedUses: string | undefined;

--- a/packages/cdkactions/src/job.ts
+++ b/packages/cdkactions/src/job.ts
@@ -71,6 +71,25 @@ export type StepConfig = RunStep | UsesStep;
 /** @deprecated Use StepConfig instead. */
 export type StepsProps = StepConfig;
 
+export interface StepRef {
+  output(key: string): Expression<string>;
+}
+
+/**
+ * Wraps a step config with an `output()` method for type-safe step output references.
+ * The step must have an `id` so that outputs can be resolved via `steps.<id>.outputs.<key>`.
+ */
+export function step<T extends StepConfig & { readonly id: string }>(config: T): T & StepRef {
+  const ref: T & StepRef = {
+    ...config,
+    output(key: string): Expression<string> {
+      return expr<string>(`steps.${config.id}.outputs.${key}`);
+    },
+  };
+  Object.defineProperty(ref, 'output', { enumerable: false });
+  return ref;
+}
+
 export type MatrixDefinition = Record<string, ReadonlyArray<string | number | boolean>>;
 
 type MatrixEntry<TMatrix extends MatrixDefinition> = Partial<{

--- a/packages/cdkactions/src/job.ts
+++ b/packages/cdkactions/src/job.ts
@@ -1,11 +1,11 @@
 import { Construct } from 'constructs';
 
-import { and, expr, type Expression } from '#src/expressions.ts';
+import { and, expr, type Expression, github, type GitHubContextFor } from '#src/expressions.ts';
 import type { RunnerLabel, Shell } from '#src/nominal.ts';
 import type { DefaultsProps, StringMap } from '#src/types.ts';
 import { renameKeys, type Writable } from '#src/utils.ts';
 import { addJobValidation } from '#src/validation.ts';
-import type { Permissions, Workflow } from '#src/workflow.ts';
+import type { Permissions, Workflow, WorkflowTrigger } from '#src/workflow.ts';
 
 /**
  * Credentials to connect to a Docker registry with.
@@ -41,16 +41,18 @@ export interface RunnerGroupConfig {
   readonly labels?: RunnerLabel[];
 }
 
-export interface StepBase {
+export type IfCondition<TOn = unknown> = Expression<boolean> | ((github: GitHubContextFor<TOn>) => Expression<boolean>);
+
+export interface StepBase<TOn = unknown> {
   readonly id?: string;
   readonly name?: string;
-  readonly if?: Expression<boolean>;
+  readonly if?: IfCondition<TOn>;
   readonly env?: StringMap;
   readonly continueOnError?: boolean;
   readonly timeoutMinutes?: number;
 }
 
-export interface RunStep extends StepBase {
+export interface RunStep<TOn = unknown> extends StepBase<TOn> {
   readonly run: string;
   readonly shell?: Shell;
   readonly workingDirectory?: string;
@@ -58,7 +60,7 @@ export interface RunStep extends StepBase {
   readonly with?: never;
 }
 
-export interface UsesStep extends StepBase {
+export interface UsesStep<TOn = unknown> extends StepBase<TOn> {
   readonly uses: string;
   readonly with?: { [key: string]: string | number | boolean };
   readonly run?: never;
@@ -66,7 +68,7 @@ export interface UsesStep extends StepBase {
   readonly workingDirectory?: never;
 }
 
-export type StepConfig = RunStep | UsesStep;
+export type StepConfig<TOn = unknown> = RunStep<TOn> | UsesStep<TOn>;
 
 /** @deprecated Use StepConfig instead. */
 export type StepsProps = StepConfig;
@@ -79,7 +81,7 @@ export interface StepRef {
  * Wraps a step config with an `output()` method for type-safe step output references.
  * The step must have an `id` so that outputs can be resolved via `steps.<id>.outputs.<key>`.
  */
-export function step<T extends StepConfig & { readonly id: string }>(config: T): T & StepRef {
+export function step<T extends StepConfig<any> & { readonly id: string }>(config: T): T & StepRef {
   const ref: T & StepRef = {
     ...config,
     output(key: string): Expression<string> {
@@ -119,15 +121,15 @@ export function createMatrixProxy<TMatrix extends MatrixDefinition>(_matrix: TMa
 /**
  * Configuration for a single GitHub Action job.
  */
-export interface JobProps<TMatrix extends MatrixDefinition = MatrixDefinition> {
+export interface JobProps<TMatrix extends MatrixDefinition = MatrixDefinition, TOn extends WorkflowTrigger = WorkflowTrigger> {
   readonly name?: string;
   readonly needs?: string | string[];
   readonly runsOn?: RunnerLabel | RunnerLabel[] | RunnerGroupConfig | Expression<string>;
   readonly outputs?: StringMap;
   readonly env?: StringMap;
   readonly defaults?: DefaultsProps;
-  readonly if?: Expression<boolean>;
-  readonly steps?: StepConfig[];
+  readonly if?: IfCondition<TOn>;
+  readonly steps?: StepConfig<TOn>[];
   readonly secrets?: Record<string, string | Expression<string>> | 'inherit';
   readonly timeoutMinutes?: number;
   readonly strategy?: StrategyProps<TMatrix>;
@@ -137,23 +139,23 @@ export interface JobProps<TMatrix extends MatrixDefinition = MatrixDefinition> {
   readonly permissions?: Permissions;
   readonly environment?: EnvironmentConfig;
   readonly concurrency?: ConcurrencyConfig;
-  readonly uses?: Workflow | string;
+  readonly uses?: Workflow<any> | string;
   readonly with?: { [key: string]: string | number | boolean };
 }
 
 /**
  * Represents a GH Actions job.
  */
-export class Job<TMatrix extends MatrixDefinition = MatrixDefinition> extends Construct {
-  protected readonly action: Writable<JobProps<TMatrix>>;
+export class Job<TMatrix extends MatrixDefinition = MatrixDefinition, TOn extends WorkflowTrigger = WorkflowTrigger> extends Construct {
+  protected readonly action: Writable<JobProps<TMatrix, TOn>>;
   public readonly id: string;
   public if?: Expression<boolean>;
   public readonly matrix: MatrixProxy<TMatrix>;
 
-  public constructor(scope: Workflow, id: string, config: JobProps<TMatrix>) {
+  public constructor(scope: Workflow<TOn>, id: string, config: JobProps<TMatrix, TOn>) {
     super(scope, id);
     this.id = id;
-    this.action = config as Writable<JobProps<TMatrix>>;
+    this.action = config as Writable<JobProps<TMatrix, TOn>>;
     this.matrix = createMatrixProxy((config.strategy?.matrix ?? {}) as TMatrix);
     addJobValidation(this, () => ({
       id: this.id,
@@ -179,14 +181,15 @@ export class Job<TMatrix extends MatrixDefinition = MatrixDefinition> extends Co
     return this.action.name;
   }
 
-  get steps(): StepConfig[] {
-    return (this.action.steps || []) as StepConfig[];
+  get steps(): StepConfig<TOn>[] {
+    return (this.action.steps || []) as StepConfig<TOn>[];
   }
 
   public toGHAction(): any {
-    const { uses, runsOn, steps, strategy, ...rest } = this.action;
+    const { uses, runsOn, steps, strategy, if: propsIf, ...rest } = this.action;
 
-    const conditions = [this.if, this.action.if].filter((c): c is Expression<boolean> => c !== undefined);
+    const resolvedIf = typeof propsIf === 'function' ? propsIf(github as any) : propsIf;
+    const conditions = [this.if, resolvedIf].filter((c): c is Expression<boolean> => c !== undefined);
     const _if = conditions.length > 0 ? and(...conditions) : undefined;
 
     let serializedUses: string | undefined;
@@ -219,12 +222,13 @@ export class Job<TMatrix extends MatrixDefinition = MatrixDefinition> extends Co
       };
     }
 
-    const serializedSteps = steps?.map((step) => {
-      const { if: stepIf, ...stepRest } = step;
+    const serializedSteps = steps?.map((s) => {
+      const { if: stepIf, ...stepRest } = s;
+      const resolvedStepIf = typeof stepIf === 'function' ? stepIf(github as any) : stepIf;
       const serialized = renameKeys(stepRest, keyMap);
       return {
         ...serialized,
-        ...(stepIf !== undefined ? { if: stepIf } : {}),
+        ...(resolvedStepIf !== undefined ? { if: resolvedStepIf } : {}),
       };
     });
 
@@ -258,7 +262,7 @@ export class Job<TMatrix extends MatrixDefinition = MatrixDefinition> extends Co
   }
 
   public addDependency(
-    dependee: Job,
+    dependee: Job<any, any>,
     options?: {
       condition?: 'success' | 'failure' | 'always' | 'completed';
     },

--- a/packages/cdkactions/src/utils.ts
+++ b/packages/cdkactions/src/utils.ts
@@ -12,6 +12,9 @@ export const renameKeys = (obj: any, newKeys: StringMap) => {
   if (typeof obj !== 'object') {
     return obj;
   }
+  if (typeof obj[Symbol.toPrimitive] === 'function') {
+    return String(obj);
+  }
   const keyValues = Object.keys(obj).map((key) => {
     const newKey = newKeys[key] || key;
     const oldValue = obj[key];

--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 
 import { Construct, Node } from 'constructs';
 
-import type { Expression } from '#src/expressions.ts';
+import type { AnyExpression } from '#src/expressions.ts';
 import { type ConcurrencyConfig, Job } from '#src/job.ts';
 import type { DefaultsProps, StringMap } from '#src/types.ts';
 import { camelToSnake, renameKeys, type Writable } from '#src/utils.ts';
@@ -353,7 +353,7 @@ export type WorkflowTrigger =
 
 export interface WorkflowProps {
   readonly name: string;
-  readonly runName?: string | Expression<string>;
+  readonly runName?: string | AnyExpression<string>;
   readonly on: WorkflowTrigger;
   readonly env?: StringMap;
   readonly concurrency?: ConcurrencyConfig;
@@ -391,9 +391,7 @@ export class Workflow<TOn extends WorkflowTrigger = WorkflowTrigger> extends Con
     if (typeof on === 'string') throw new Error();
 
     this.action.on =
-      'workflowRun' in on
-        ? { ...on, workflowRun: { ...on.workflowRun } }
-        : { workflowRun: { workflows: [] } };
+      'workflowRun' in on ? { ...on, workflowRun: { ...on.workflowRun } } : { workflowRun: { workflows: [] } };
 
     (this.action.on as any).workflowRun.workflows ||= [];
     (this.action.on as any).workflowRun.workflows.push(dependee.action.name);

--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -341,18 +341,20 @@ export interface PermissionsMap {
 
 export type Permissions = PermissionsMap | 'read-all' | 'write-all';
 
+export type WorkflowTrigger =
+  | Events
+  | Array<Events>
+  | EventMap
+  | ScheduleEvent
+  | WorkflowRunEvent
+  | WorkflowDispatchEvent
+  | MergeGroupEvent
+  | WorkflowCallEvent;
+
 export interface WorkflowProps {
   readonly name: string;
   readonly runName?: string | Expression<string>;
-  readonly on:
-    | Events
-    | Array<Events>
-    | EventMap
-    | ScheduleEvent
-    | WorkflowRunEvent
-    | WorkflowDispatchEvent
-    | MergeGroupEvent
-    | WorkflowCallEvent;
+  readonly on: WorkflowTrigger;
   readonly env?: StringMap;
   readonly concurrency?: ConcurrencyConfig;
   readonly defaults?: DefaultsProps;
@@ -368,14 +370,14 @@ function isPushEvent(on: WorkflowProps['on']): on is { push: NonNullable<EventMa
 const excessSpaces = /[\s{2,}]/g;
 const whiteSeparators = /[\n\t]/g;
 
-export class Workflow extends Construct {
+export class Workflow<TOn extends WorkflowTrigger = WorkflowTrigger> extends Construct {
   public readonly outputFile: string;
-  private readonly action: Writable<WorkflowProps>;
+  private readonly action: Writable<Omit<WorkflowProps, 'on'> & { on: TOn }>;
 
-  public constructor(scope: Construct, id: string, config: WorkflowProps) {
+  public constructor(scope: Construct, id: string, config: Omit<WorkflowProps, 'on'> & { readonly on: TOn }) {
     const sanitizedId = id.replace(excessSpaces, '-').replace(whiteSeparators, '').trim().toLowerCase();
     super(scope, id);
-    this.action = config;
+    this.action = config as Writable<Omit<WorkflowProps, 'on'> & { on: TOn }>;
     this.outputFile = `cdkactions_${sanitizedId}.yaml`;
     addWorkflowValidation(this, () => ({
       name: this.action.name,
@@ -383,37 +385,43 @@ export class Workflow extends Construct {
     }));
   }
 
-  public addDependency(dependee: Workflow) {
-    if (Array.isArray(this.action.on)) throw new Error();
-    if (typeof this.action.on === 'string') throw new Error();
+  public addDependency(dependee: Workflow<any>) {
+    const on: any = this.action.on;
+    if (Array.isArray(on)) throw new Error();
+    if (typeof on === 'string') throw new Error();
 
     this.action.on =
-      'workflowRun' in this.action.on
-        ? { ...this.action.on, workflowRun: { ...this.action.on.workflowRun } }
+      'workflowRun' in on
+        ? { ...on, workflowRun: { ...on.workflowRun } }
         : { workflowRun: { workflows: [] } };
 
-    this.action.on.workflowRun.workflows ||= [];
-    this.action.on.workflowRun.workflows.push(dependee.action.name);
+    (this.action.on as any).workflowRun.workflows ||= [];
+    (this.action.on as any).workflowRun.workflows.push(dependee.action.name);
 
     return this;
   }
 
   public toGHAction(): any {
-    if (isPushEvent(this.action.on)) {
-      if (this.action.on.push.paths) {
-        this.action.on.push.paths.unshift(`.github/workflows/${this.outputFile}`);
+    const on: any = this.action.on;
+
+    if (isPushEvent(on)) {
+      if (on.push.paths) {
+        on.push.paths.unshift(`.github/workflows/${this.outputFile}`);
       }
     }
 
-    if (typeof this.action.on !== 'string' && 'workflowRun' in this.action.on) {
-      assert(this.action.on.workflowRun.workflows?.length, `${this.action.name} must specify workflows it depends on`);
+    if (typeof on !== 'string' && 'workflowRun' in on) {
+      assert(on.workflowRun.workflows?.length, `${this.action.name} must specify workflows it depends on`);
     }
 
-    if (typeof this.action.on === 'object' && !Array.isArray(this.action.on) && 'schedule' in this.action.on) {
-      this.action.on.schedule = this.action.on.schedule.map((entry) => ({
-        ...entry,
-        cron: entry.cron instanceof CronExpression ? entry.cron.toString() : entry.cron,
-      }));
+    if (typeof on === 'object' && !Array.isArray(on) && 'schedule' in on) {
+      (this.action as any).on = {
+        ...on,
+        schedule: on.schedule.map((entry: any) => ({
+          ...entry,
+          cron: entry.cron instanceof CronExpression ? entry.cron.toString() : entry.cron,
+        })),
+      };
     }
 
     const workflow = renameKeys(this.action, {

--- a/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
+++ b/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
@@ -388,10 +388,13 @@ jobs:
 name: Deploy
 on:
   workflow_run:
+    types:
+      - completed
     workflows:
       - CI
 jobs:
   deploy:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Deploy

--- a/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
+++ b/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
@@ -354,7 +354,7 @@ on:
       - main
 jobs:
   deploy:
-    if: (github.ref == 'refs/heads/main' && !(github.actor == 'dependabot[bot]'))
+    if: (github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Deploy

--- a/packages/cdkactions/test/expressions.test.ts
+++ b/packages/cdkactions/test/expressions.test.ts
@@ -3,6 +3,7 @@ import {
   and,
   cancelled,
   contains,
+  type AnyExpression,
   type Expression,
   endsWith,
   env,
@@ -36,7 +37,7 @@ import {
 import { expr } from '#src/expressions.ts';
 
 /** Strips token delimiters to check the raw expression text. */
-function raw(e: Expression): string {
+function raw(e: AnyExpression): string {
   return unwrapToken(String(e));
 }
 
@@ -222,11 +223,11 @@ test('expressions compose correctly', () => {
   expect(raw(isNotBot)).toBe("github.actor != 'dependabot[bot]'");
 });
 
-// Expression<string> context properties are typed correctly
-const _refType: Expression<string> = github.ref;
-const _osType: Expression<string> = runner.os;
-const _boolType: Expression<boolean> = github.refProtected;
-const _numType: Expression<number> = strategy.jobIndex;
+// Context properties are typed as DeepExpression (not string-based)
+const _refType: DeepExpression<string> = github.ref;
+const _osType: DeepExpression<string> = runner.os;
+const _boolType: DeepExpression<boolean> = github.refProtected;
+const _numType: DeepExpression<number> = strategy.jobIndex;
 
 // Status check functions return Expression<boolean>
 const _successType: Expression<boolean> = success();
@@ -243,12 +244,14 @@ import type { InferEventPayload, GitHubContextFor, DeepExpression } from '#src/e
 import type { PullRequestEventPayload, WorkflowRunEventPayload } from '#src/expressions.ts';
 
 type _PRPayload = InferEventPayload<{ pullRequest: null }>;
-const _prDraft: DeepExpression<PullRequestEventPayload['pullRequest']['draft']> =
-  {} as DeepExpression<_PRPayload['pullRequest']['draft']>;
+const _prDraft: DeepExpression<PullRequestEventPayload['pullRequest']['draft']> = {} as DeepExpression<
+  _PRPayload['pullRequest']['draft']
+>;
 
 type _WRPayload = InferEventPayload<{ workflowRun: { workflows: string[] } }>;
-const _wrConclusion: DeepExpression<WorkflowRunEventPayload['workflowRun']['conclusion']> =
-  {} as DeepExpression<_WRPayload['workflowRun']['conclusion']>;
+const _wrConclusion: DeepExpression<WorkflowRunEventPayload['workflowRun']['conclusion']> = {} as DeepExpression<
+  _WRPayload['workflowRun']['conclusion']
+>;
 
 // GitHubContextFor narrows event property
 type _NarrowedCtx = GitHubContextFor<{ pullRequest: null }>;
@@ -318,9 +321,8 @@ test('deep proxy renames camelCase to snake_case on github context', () => {
 });
 
 test('deep proxy values work in composed expressions', () => {
-  const condition = and(
-    eq(github.eventName, 'issue_comment'),
-    contains(github.event.comment.body, '@claude'),
+  const condition = and(eq(github.eventName, 'issue_comment'), contains(github.event.comment.body, '@claude'));
+  expect(raw(condition)).toBe(
+    "(github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))",
   );
-  expect(raw(condition)).toBe("(github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))");
 });

--- a/packages/cdkactions/test/expressions.test.ts
+++ b/packages/cdkactions/test/expressions.test.ts
@@ -243,12 +243,12 @@ import type { InferEventPayload, GitHubContextFor, DeepExpression } from '#src/e
 import type { PullRequestEventPayload, WorkflowRunEventPayload } from '#src/expressions.ts';
 
 type _PRPayload = InferEventPayload<{ pullRequest: null }>;
-const _prDraft: DeepExpression<PullRequestEventPayload['pull_request']['draft']> =
-  {} as DeepExpression<_PRPayload['pull_request']['draft']>;
+const _prDraft: DeepExpression<PullRequestEventPayload['pullRequest']['draft']> =
+  {} as DeepExpression<_PRPayload['pullRequest']['draft']>;
 
 type _WRPayload = InferEventPayload<{ workflowRun: { workflows: string[] } }>;
-const _wrConclusion: DeepExpression<WorkflowRunEventPayload['workflow_run']['conclusion']> =
-  {} as DeepExpression<_WRPayload['workflow_run']['conclusion']>;
+const _wrConclusion: DeepExpression<WorkflowRunEventPayload['workflowRun']['conclusion']> =
+  {} as DeepExpression<_WRPayload['workflowRun']['conclusion']>;
 
 // GitHubContextFor narrows event property
 type _NarrowedCtx = GitHubContextFor<{ pullRequest: null }>;
@@ -308,6 +308,13 @@ test('deep proxy values work with contains()', () => {
 
 test('deep proxy values work with not()', () => {
   expect(raw(not(github.event.pull_request.draft as Expression<boolean>))).toBe('!(github.event.pull_request.draft)');
+});
+
+test('deep proxy renames camelCase to snake_case on github context', () => {
+  expect(raw(github.event.pullRequest.draft)).toBe('github.event.pull_request.draft');
+  expect(raw(github.event.workflowRun.conclusion)).toBe('github.event.workflow_run.conclusion');
+  expect(raw(github.event.workflowRun.headBranch)).toBe('github.event.workflow_run.head_branch');
+  expect(raw(github.event.release.tagName)).toBe('github.event.release.tag_name');
 });
 
 test('deep proxy values work in composed expressions', () => {

--- a/packages/cdkactions/test/expressions.test.ts
+++ b/packages/cdkactions/test/expressions.test.ts
@@ -1,5 +1,6 @@
 import {
   always,
+  and,
   cancelled,
   contains,
   type Expression,
@@ -246,3 +247,54 @@ void _successType;
 void _failureType;
 void _eqType;
 void _notType;
+
+// --- Recursive proxy tests ---
+
+test('github.event allows deep property access', () => {
+  expect(raw(github.event.comment.body)).toBe('github.event.comment.body');
+  expect(raw(github.event.pull_request.draft)).toBe('github.event.pull_request.draft');
+  expect(raw(github.event.release.tag_name)).toBe('github.event.release.tag_name');
+  expect(raw(github.event.workflow_run.conclusion)).toBe('github.event.workflow_run.conclusion');
+});
+
+test('needs context allows deep property access', () => {
+  expect(raw(needs.build.result)).toBe('needs.build.result');
+  expect(raw(needs.build.outputs.artifact_url)).toBe('needs.build.outputs.artifact_url');
+  expect(raw(needs['my-job'].result)).toBe('needs.my-job.result');
+});
+
+test('steps context allows deep property access', () => {
+  expect(raw(steps.checkout.outputs.ref)).toBe('steps.checkout.outputs.ref');
+  expect(raw(steps.check.outputs.needs_update)).toBe('steps.check.outputs.needs_update');
+  expect(raw(steps.resolve.conclusion)).toBe('steps.resolve.conclusion');
+});
+
+test('job context allows deep property access', () => {
+  expect(raw(job.container.id)).toBe('job.container.id');
+  expect(raw(job.container.network)).toBe('job.container.network');
+});
+
+test('deep proxy values work with eq()', () => {
+  expect(raw(eq(needs.build.result, 'success'))).toBe("needs.build.result == 'success'");
+  expect(raw(eq(steps.check.outputs.needs_update, 'true'))).toBe("steps.check.outputs.needs_update == 'true'");
+});
+
+test('deep proxy values work with neq()', () => {
+  expect(raw(neq(steps.resolve.outputs.skip, 'true'))).toBe("steps.resolve.outputs.skip != 'true'");
+});
+
+test('deep proxy values work with contains()', () => {
+  expect(raw(contains(github.event.comment.body, '@claude'))).toBe("contains(github.event.comment.body, '@claude')");
+});
+
+test('deep proxy values work with not()', () => {
+  expect(raw(not(github.event.pull_request.draft as Expression<boolean>))).toBe('!(github.event.pull_request.draft)');
+});
+
+test('deep proxy values work in composed expressions', () => {
+  const condition = and(
+    eq(github.eventName, 'issue_comment'),
+    contains(github.event.comment.body, '@claude'),
+  );
+  expect(raw(condition)).toBe("(github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))");
+});

--- a/packages/cdkactions/test/expressions.test.ts
+++ b/packages/cdkactions/test/expressions.test.ts
@@ -238,6 +238,22 @@ const _eqType: Expression<boolean> = eq(github.ref, 'main');
 // not accepts and returns Expression<boolean>
 const _notType: Expression<boolean> = not(github.refProtected);
 
+// Type-level: InferEventPayload narrows event type correctly
+import type { InferEventPayload, GitHubContextFor, DeepExpression } from '#src/expressions.ts';
+import type { PullRequestEventPayload, WorkflowRunEventPayload } from '#src/expressions.ts';
+
+type _PRPayload = InferEventPayload<{ pullRequest: null }>;
+const _prDraft: DeepExpression<PullRequestEventPayload['pull_request']['draft']> =
+  {} as DeepExpression<_PRPayload['pull_request']['draft']>;
+
+type _WRPayload = InferEventPayload<{ workflowRun: { workflows: string[] } }>;
+const _wrConclusion: DeepExpression<WorkflowRunEventPayload['workflow_run']['conclusion']> =
+  {} as DeepExpression<_WRPayload['workflow_run']['conclusion']>;
+
+// GitHubContextFor narrows event property
+type _NarrowedCtx = GitHubContextFor<{ pullRequest: null }>;
+const _narrowedEvent: DeepExpression<PullRequestEventPayload> = {} as _NarrowedCtx['event'];
+
 // Suppress unused variable warnings
 void _refType;
 void _osType;
@@ -247,6 +263,9 @@ void _successType;
 void _failureType;
 void _eqType;
 void _notType;
+void _prDraft;
+void _wrConclusion;
+void _narrowedEvent;
 
 // --- Recursive proxy tests ---
 

--- a/packages/cdkactions/test/job.test.ts
+++ b/packages/cdkactions/test/job.test.ts
@@ -678,6 +678,27 @@ test('step if with Expression emits without ${{ }} wrapping', () => {
   expect(ghAction.steps[0].if).toBe("github.event_name == 'push'");
 });
 
+test('step() helper returns config with output() method', () => {
+  const { step } = require('#src/index.ts');
+  const s = step({ id: 'deploy', uses: 'actions/deploy-pages@v4' });
+  expect(s.id).toBe('deploy');
+  expect(s.uses).toBe('actions/deploy-pages@v4');
+  expect(unwrapToken(String(s.output('page_url')))).toBe('steps.deploy.outputs.page_url');
+});
+
+test('step() output is non-enumerable', () => {
+  const { step } = require('#src/index.ts');
+  const s = step({ id: 'build', run: 'npm run build' });
+  expect(Object.keys(s)).not.toContain('output');
+});
+
+test('step() output serializes correctly in resolveTokens', () => {
+  const { step } = require('#src/index.ts');
+  const s = step({ id: 'check', uses: 'actions/check@v1' });
+  const resolved = resolveTokens({ url: `${s.output('result')}` });
+  expect((resolved as any).url).toBe('${{ steps.check.outputs.result }}');
+});
+
 // Type-level: JobProps.if accepts Expression<boolean>
 const _jobIfExpr: Pick<JobProps, 'if'> = { if: expr<boolean>('true') };
 

--- a/packages/cdkactions/test/job.test.ts
+++ b/packages/cdkactions/test/job.test.ts
@@ -699,8 +699,36 @@ test('step() output serializes correctly in resolveTokens', () => {
   expect((resolved as any).url).toBe('${{ steps.check.outputs.result }}');
 });
 
+test('job if with function form resolves to expression', () => {
+  const job = new Job(TestingWorkflow(), 'test', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    if: (gh) => eq(gh.eventName, 'push'),
+    steps: [{ name: 'Run', run: 'echo ok' }],
+  });
+  const ghAction = serialize(job);
+  expect(ghAction.if).toBe("github.event_name == 'push'");
+});
+
+test('step if with function form resolves to expression', () => {
+  const job = new Job(TestingWorkflow(), 'test', {
+    runsOn: RunnerLabel.UBUNTU_LATEST,
+    steps: [
+      {
+        name: 'Run',
+        run: 'echo ok',
+        if: (gh) => eq(gh.eventName, 'push'),
+      },
+    ],
+  });
+  const ghAction = serialize(job);
+  expect(ghAction.steps[0].if).toBe("github.event_name == 'push'");
+});
+
 // Type-level: JobProps.if accepts Expression<boolean>
 const _jobIfExpr: Pick<JobProps, 'if'> = { if: expr<boolean>('true') };
+
+// Type-level: JobProps.if accepts function form
+const _jobIfFn: Pick<JobProps, 'if'> = { if: (gh) => eq(gh.eventName, 'push') };
 
 // Type-level: JobProps.if rejects raw string
 // @ts-expect-error - raw string should not be assignable to Expression<boolean>


### PR DESCRIPTION
## Summary

- **Recursive context proxies**: `github.event`, `needs`, `steps`, `job` now support deep property access (e.g., `github.event.pullRequest.draft`, `needs.build.outputs.artifactUrl`, `steps.checkout.outputs.ref`). Properties are automatically renamed from camelCase to snake_case on the `github` context.

- **Event payload type inference**: Workflow trigger configuration (`on:`) narrows `github.event` to the correct payload type. For example, a workflow with `pullRequest` trigger gets `github.event.pullRequest.draft` as `DeepExpression<boolean>`. Supports `pullRequest`, `issueComment`, `issues`, `release`, `workflowRun`, `push`, and more.

- **Function-form `if` conditions**: `if` on jobs and steps accepts a callback `(github) => Expression<boolean>` where `github` is narrowed based on the workflow's trigger, enabling type-safe access to event-specific properties.

- **`step()` helper**: Wraps a step config with a typed `.output(key)` method for referencing step outputs without manual `expr()` strings.

- **Context proxy types no longer extend `string`**: Introduces `AnyExpression<T>` as the minimal branded base type. `DeepExpression<T>` (used for all context interface properties) no longer inherits `String.prototype` methods (`charAt`, `charCodeAt`, etc.), since context proxies are not real strings. Function parameters accept `AnyExpression<T>` so both `Expression<T>` (from builders) and `DeepExpression<T>` (from proxies) work as inputs. Action input values (`with:`) also accept `AnyExpression`.

- **`inputs.*` typed as `Expression<string>`**: Workflow inputs are always strings in GitHub Actions.

## Test plan
- [x] All 187 tests pass
- [x] Build clean (no type errors)
- [x] Snapshot updated for new expression output
- [x] Type-level tests verify context properties are `DeepExpression`, not `Expression`
- [x] Examples updated to use recursive proxies and function-form conditions