### PR TITLE
feat: outputs proxy and Job.addOutput for workflowCall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,34 @@ Walk up the construct tree to find the enclosing Stack. Used by `CompositeAction
 - `Job.addDependency(job)` → adds to `needs` array
 - `Workflow.addDependency(workflow)` → sets up `workflow_run` trigger
 
+### Key Pattern: `Job.outputs` and `Job.addOutput`
+
+`Job.outputs` is a Proxy that generates `jobs.<id>.outputs.<key>` expressions on property access:
+
+```typescript
+const buildJob = new Job(workflow, 'build', { ... });
+// buildJob.outputs.hash → Expression<string> for "jobs.build.outputs.hash"
+```
+
+`Job.addOutput(name, outputKey, description)` registers a workflow-level output on `workflowCall` triggers. It is only callable when the parent workflow uses `workflowCall` (enforced at the type level):
+
+```typescript
+new Job(reusable, 'build', { ... })
+  .addOutput('buildHash', 'hash', 'SHA of the build output');
+```
+
+### Key Pattern: Step `outputs` proxy
+
+Steps wrapped with `step()`, `defineAction()`, or `CompositeAction.asStep()` expose an `outputs` proxy for type-safe step output references:
+
+```typescript
+const deploy = step({ id: 'deploy', uses: 'actions/deploy-pages@v4' });
+deploy.outputs.page_url  // → Expression<string> for "steps.deploy.outputs.page_url"
+
+const co = checkoutV4({ id: 'co' });
+co.outputs.ref  // → typed Expression<string>
+```
+
 ## TypeScript Conventions
 
 ### Property Naming
@@ -124,7 +152,7 @@ This pattern allows strict enforcement of valid runner labels at the type level 
 
 External GitHub Actions are defined centrally with full input/output type safety using `defineAction<TInputs, TOutputs>(ref)`. The generic type parameters capture the action's input schema (required vs optional, defaults) and output schema. Pre-defined action references (e.g., `checkoutV2`, `checkoutV3`, `checkoutV4`) live in `src/actions.ts`.
 
-Actions are **directly callable** — `checkoutV4()` or `checkoutV4({ with: { fetchDepth: 0 } })`. When all inputs are optional and there are no outputs, the parameter is optional. The return is a `TypedUsesStep<TOutputs>` — a subtype of `UsesStep` with a typed `.output(key)` accessor. This slots seamlessly into the `StepConfig` union. Each action also exposes `.ref` and `.uses` properties for the raw reference string.
+Actions are **directly callable** — `checkoutV4()` or `checkoutV4({ with: { fetchDepth: 0 } })`. When all inputs are optional and there are no outputs, the parameter is optional. The return is a `TypedUsesStep<TOutputs>` — a subtype of `UsesStep` with a typed `.outputs` proxy for property-based output access. This slots seamlessly into the `StepConfig` union. Each action also exposes `.ref` and `.uses` properties for the raw reference string.
 
 Key design rules:
 - Input keys use **camelCase** in TypeScript, serialized to **kebab-case** in YAML (e.g., `fetchDepth` → `fetch-depth`)
@@ -161,12 +189,14 @@ Composition uses free functions: `and(a, b)`, `or(a, b)`, `eq(left, right)`, `no
 This means expressions work transparently everywhere — no manual `${{ }}` wrapping needed:
 
 ```typescript
-// Expressions in with/env are auto-wrapped during synthesis
+// Context proxies (DeepExpression<string>) are accepted directly in with/env/outputs
 { with: { username: github.actor, password: secrets.GITHUB_TOKEN } }
 
 // Expressions in string interpolation are also auto-resolved
 { group: `docker-${github.ref}` }  // → "docker-${{ github.ref }}"
 ```
+
+**Type hierarchy:** `Expression<T>` extends `string` (usable anywhere strings are). `DeepExpression<T>` does NOT extend `string` — this hides `String.prototype` methods from autocomplete on context proxies. Instead, all value-accepting positions (`StringMap`, `with`, `env`, `outputs`, `EnvironmentConfig.url`, etc.) explicitly accept `AnyExpression` alongside `string`.
 
 ## Synthesis
 

--- a/packages/cdkactions/examples/03-multi-job-pipeline.ts
+++ b/packages/cdkactions/examples/03-multi-job-pipeline.ts
@@ -13,7 +13,7 @@ export function create(app?: App) {
   const upload = uploadArtifactV4({ id: 'upload', with: { name: 'dist', path: 'dist/' } });
   const build = new Job(workflow, 'build', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
-    outputs: { artifact_id: `${upload.output('artifactId')}` },
+    outputs: { artifact_id: upload.outputs.artifactId },
     steps: [checkoutV4(), { name: 'Build', run: 'npm run build' }, upload],
   });
 

--- a/packages/cdkactions/examples/06-reusable-workflow.ts
+++ b/packages/cdkactions/examples/06-reusable-workflow.ts
@@ -1,4 +1,4 @@
-import { App, Stack, Workflow, Job, RunnerLabel, WorkflowDispatchInputType, expr } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, WorkflowDispatchInputType } from '#src/index.ts';
 import { checkoutV4 } from '#src/actions.ts';
 
 export function create(app?: App) {
@@ -22,12 +22,6 @@ export function create(app?: App) {
             default: true,
           },
         },
-        outputs: {
-          buildHash: {
-            description: 'SHA of the build output',
-            value: `${expr('jobs.build.outputs.hash')}`,
-          },
-        },
         secrets: {
           npmToken: { required: true },
           sentryDsn: { required: false },
@@ -39,7 +33,7 @@ export function create(app?: App) {
   new Job(reusable, 'build', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
     steps: [checkoutV4(), { name: 'Build', run: 'npm run build' }],
-  });
+  }).addOutput('buildHash', 'hash', 'SHA of the build output');
 
   const caller = new Workflow(stack, 'release', {
     name: 'Release',

--- a/packages/cdkactions/examples/08-composite-action.ts
+++ b/packages/cdkactions/examples/08-composite-action.ts
@@ -18,12 +18,9 @@ export function create(app?: App) {
       registry: { description: 'npm registry URL', required: false, default: 'https://registry.npmjs.org' },
     },
     outputs: {
-      cacheHit: { description: 'Whether cache was hit', value: cacheStep.output('cache-hit') },
+      cacheHit: { description: 'Whether cache was hit', value: cacheStep.outputs['cache-hit'] },
     },
-    steps: [
-      cacheStep,
-      { name: 'Install', run: 'npm ci', shell: Shell.BASH },
-    ],
+    steps: [cacheStep, { name: 'Install', run: 'npm ci', shell: Shell.BASH }],
   } as const);
 
   const workflow = new Workflow(stack, 'ci', {
@@ -42,7 +39,7 @@ export function create(app?: App) {
   });
 
   // Verify typed output accessor works
-  const _cacheHit: string = setupStep.output('cacheHit');
+  const _cacheHit: string = setupStep.outputs.cacheHit;
 
   return _app;
 }

--- a/packages/cdkactions/examples/13-github-pages.ts
+++ b/packages/cdkactions/examples/13-github-pages.ts
@@ -32,7 +32,7 @@ export function create(app?: App) {
 
   const deploy = new Job(workflow, 'deploy', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
-    environment: { name: 'github-pages', url: deploymentStep.output('page_url') },
+    environment: { name: 'github-pages', url: deploymentStep.outputs.page_url },
     steps: [deploymentStep],
   });
   deploy.addDependency(build);

--- a/packages/cdkactions/examples/16-typed-action-refs.ts
+++ b/packages/cdkactions/examples/16-typed-action-refs.ts
@@ -65,9 +65,9 @@ export function create(app?: App) {
     with: { name: 'dist', path: 'dist/' },
   });
 
-  co.output('commit');
-  node.output('cacheHit');
-  upload.output('artifactId');
+  co.outputs.commit;
+  node.outputs.cacheHit;
+  upload.outputs.artifactId;
 
   new Job(workflow, 'build', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
@@ -84,4 +84,4 @@ checkoutV4({ id: 'x', with: { branchName: 'main' } });
 uploadArtifactV4({ id: 'x', with: { path: 'dist/' } });
 
 // @ts-expect-error — 'digest' is not an output of checkout
-checkoutV4({ id: 'x' }).output('digest');
+checkoutV4({ id: 'x' }).outputs.digest;

--- a/packages/cdkactions/examples/17-type-level-tests.ts
+++ b/packages/cdkactions/examples/17-type-level-tests.ts
@@ -1,5 +1,5 @@
-import { Workflow, Job, RunnerLabel, defineAction, createMatrixProxy } from '#src/index.ts';
-import type { PermissionsMap, RunStep, UsesStep, StepConfig, Expression } from '#src/index.ts';
+import { Workflow, Job, RunnerLabel, defineAction, createMatrixProxy, github } from '#src/index.ts';
+import type { PermissionsMap, RunStep, UsesStep, StepConfig, Expression, StringMap } from '#src/index.ts';
 
 const workflow = undefined as any as Workflow;
 
@@ -64,4 +64,9 @@ _checkoutV4({ id: 'x', with: { branchName: 'main' } });
 _uploadArtifactV4({ id: 'x', with: { path: 'dist/' } });
 
 // @ts-expect-error — unknown output key on typed action ref
-_checkoutV4({ id: 'x' }).output('digest');
+_checkoutV4({ id: 'x' }).outputs.digest;
+
+// @ts-expect-error — addOutput not available on non-workflowCall workflows
+job.addOutput('hash', 'hash', 'Build hash');
+
+const _envMap: StringMap = { user: github.actor };

--- a/packages/cdkactions/src/action.ts
+++ b/packages/cdkactions/src/action.ts
@@ -36,7 +36,7 @@ type ActionCallOptions<TInputs extends ActionInputs, TOutputs extends ActionOutp
 
 export interface TypedUsesStep<TOutputs extends ActionOutputs = ActionOutputs>
   extends Omit<UsesStep, 'run' | 'shell' | 'workingDirectory'> {
-  output<K extends keyof TOutputs & string>(key: K): Expression<string>;
+  readonly outputs: { readonly [K in keyof TOutputs & string]: Expression<string> };
 }
 
 type HasRequiredCallOptions<TInputs extends ActionInputs, TOutputs extends ActionOutputs> = [
@@ -71,8 +71,18 @@ export function defineAction<
     const { id: stepId, name, if: ifProp, env, continueOnError, timeoutMinutes, with: withProp } = options ?? {};
 
     const serializedWith = withProp
-      ? Object.fromEntries(Object.entries<string | number | boolean>(withProp).map(([k, v]) => [camelToKebab(k), v]))
+      ? Object.fromEntries(Object.entries<ActionInputValue>(withProp).map(([k, v]) => [camelToKebab(k), v]))
       : undefined;
+
+    const outputs = new Proxy({} as TypedUsesStep<TOutputs>['outputs'], {
+      get(_target, prop: string | symbol): unknown {
+        if (typeof prop === 'symbol') return undefined;
+        if (!stepId) {
+          throw new Error('Cannot access outputs on a step without an id');
+        }
+        return expr<string>(`steps.${stepId}.outputs.${prop}`);
+      },
+    });
 
     const step: TypedUsesStep<TOutputs> = {
       ...(stepId !== undefined && { id: stepId }),
@@ -83,14 +93,9 @@ export function defineAction<
       ...(env !== undefined && { env }),
       ...(continueOnError !== undefined && { continueOnError }),
       ...(timeoutMinutes !== undefined && { timeoutMinutes }),
-      output<K extends keyof TOutputs & string>(key: K): Expression<string> {
-        if (!stepId) {
-          throw new Error('Cannot access outputs on a step without an id');
-        }
-        return expr<string>(`steps.${stepId}.outputs.${key}`);
-      },
+      outputs,
     };
-    Object.defineProperty(step, 'output', { enumerable: false });
+    Object.defineProperty(step, 'outputs', { enumerable: false });
 
     return step;
   };

--- a/packages/cdkactions/src/composite-action.ts
+++ b/packages/cdkactions/src/composite-action.ts
@@ -39,7 +39,7 @@ export interface CompositeActionOutputProps {
    * The value of the output, typically a context expression like
    * `${{ steps.step-id.outputs.field }}`.
    */
-  readonly value: string;
+  readonly value: string | AnyExpression<string>;
 }
 
 /**
@@ -84,9 +84,9 @@ type OptionalInputKeys<T extends Record<string, CompositeActionInputProps>> = {
 }[keyof T & string];
 
 type CompositeActionWith<T extends Record<string, CompositeActionInputProps>> = {
-  readonly [K in RequiredInputKeys<T>]: string | number | boolean;
+  readonly [K in RequiredInputKeys<T>]: string | number | boolean | AnyExpression;
 } & {
-  readonly [K in OptionalInputKeys<T>]?: string | number | boolean;
+  readonly [K in OptionalInputKeys<T>]?: string | number | boolean | AnyExpression;
 };
 
 type AsStepOptions<
@@ -100,7 +100,7 @@ type AsStepOptions<
   ([RequiredInputKeys<T>] extends [never] ? { with?: CompositeActionWith<T> } : { with: CompositeActionWith<T> });
 
 type CompositeActionStepRef<TOutputs extends Record<string, CompositeActionOutputProps>> = UsesStep & {
-  output<K extends keyof TOutputs & string>(key: K): string;
+  readonly outputs: { readonly [K in keyof TOutputs & string]: string };
 };
 
 /**
@@ -151,13 +151,20 @@ export class CompositeAction<
     const options = args[0];
     const id = options?.id;
 
+    const outputs = new Proxy({} as CompositeActionStepRef<TOutputs>['outputs'], {
+      get(_target, prop: string | symbol): unknown {
+        if (typeof prop === 'symbol') return undefined;
+        return String(expr(`steps.${id}.outputs.${prop}`));
+      },
+    });
+
     const step: UsesStep = {
       name: this.config.name,
       ...options,
       uses: this.usesPath,
     };
-    Object.defineProperty(step, 'output', {
-      value: (key: string) => String(expr(`steps.${id}.outputs.${key}`)),
+    Object.defineProperty(step, 'outputs', {
+      value: outputs,
       enumerable: false,
     });
 

--- a/packages/cdkactions/src/job.ts
+++ b/packages/cdkactions/src/job.ts
@@ -5,7 +5,7 @@ import type { RunnerLabel, Shell } from '#src/nominal.ts';
 import type { DefaultsProps, StringMap } from '#src/types.ts';
 import { renameKeys, type Writable } from '#src/utils.ts';
 import { addJobValidation } from '#src/validation.ts';
-import type { Permissions, Workflow, WorkflowTrigger } from '#src/workflow.ts';
+import type { Permissions, Workflow, WorkflowCallEvent, WorkflowTrigger } from '#src/workflow.ts';
 
 /**
  * Credentials to connect to a Docker registry with.
@@ -32,7 +32,7 @@ export interface ServiceProps extends DockerProps {
   readonly entrypoint?: string;
 }
 
-export type EnvironmentConfig = string | { readonly name: string; readonly url?: string };
+export type EnvironmentConfig = string | { readonly name: string; readonly url?: string | AnyExpression<string> };
 
 export type ConcurrencyConfig = string | { readonly group: string; readonly cancelInProgress?: boolean };
 
@@ -64,7 +64,7 @@ export interface RunStep<TOn = unknown> extends StepBase<TOn> {
 
 export interface UsesStep<TOn = unknown> extends StepBase<TOn> {
   readonly uses: string;
-  readonly with?: { [key: string]: string | number | boolean };
+  readonly with?: { [key: string]: string | number | boolean | AnyExpression };
   readonly run?: never;
   readonly shell?: never;
   readonly workingDirectory?: never;
@@ -76,21 +76,26 @@ export type StepConfig<TOn = unknown> = RunStep<TOn> | UsesStep<TOn>;
 export type StepsProps = StepConfig;
 
 export interface StepRef {
-  output(key: string): Expression<string>;
+  readonly outputs: Record<string, Expression<string>>;
 }
 
 /**
- * Wraps a step config with an `output()` method for type-safe step output references.
+ * Wraps a step config with an `outputs` proxy for type-safe step output references.
  * The step must have an `id` so that outputs can be resolved via `steps.<id>.outputs.<key>`.
  */
 export function step<T extends StepConfig<any> & { readonly id: string }>(config: T): T & StepRef {
+  const outputs = new Proxy({} as Record<string, Expression<string>>, {
+    get(_target, prop: string | symbol): unknown {
+      if (typeof prop === 'symbol') return undefined;
+      return expr<string>(`steps.${config.id}.outputs.${prop}`);
+    },
+  });
+
   const ref: T & StepRef = {
     ...config,
-    output(key: string): Expression<string> {
-      return expr<string>(`steps.${config.id}.outputs.${key}`);
-    },
+    outputs,
   };
-  Object.defineProperty(ref, 'output', { enumerable: false });
+  Object.defineProperty(ref, 'outputs', { enumerable: false });
   return ref;
 }
 
@@ -145,7 +150,7 @@ export interface JobProps<
   readonly environment?: EnvironmentConfig;
   readonly concurrency?: ConcurrencyConfig;
   readonly uses?: Workflow<any> | string;
-  readonly with?: { [key: string]: string | number | boolean };
+  readonly with?: { [key: string]: string | number | boolean | AnyExpression };
 }
 
 /**
@@ -159,12 +164,21 @@ export class Job<
   public readonly id: string;
   public if?: AnyExpression<boolean>;
   public readonly matrix: MatrixProxy<TMatrix>;
+  public readonly outputs: Record<string, Expression<string>>;
+  private readonly workflow: Workflow<TOn>;
 
   public constructor(scope: Workflow<TOn>, id: string, config: JobProps<TMatrix, TOn>) {
     super(scope, id);
     this.id = id;
+    this.workflow = scope;
     this.action = config as Writable<JobProps<TMatrix, TOn>>;
     this.matrix = createMatrixProxy((config.strategy?.matrix ?? {}) as TMatrix);
+    this.outputs = new Proxy({} as Record<string, Expression<string>>, {
+      get(_target, prop: string | symbol): unknown {
+        if (typeof prop === 'symbol') return undefined;
+        return expr<string>(`jobs.${id}.outputs.${prop}`);
+      },
+    });
     addJobValidation(this, () => ({
       id: this.id,
       steps: this.steps,
@@ -267,6 +281,14 @@ export class Job<
       ...(serializedStrategy ? { strategy: serializedStrategy } : {}),
       ...(serializedSteps ? { steps: serializedSteps } : {}),
     };
+  }
+
+  public addOutput(
+    ...args: [TOn] extends [WorkflowCallEvent] ? [name: string, outputKey: string, description: string] : never
+  ): this {
+    const [name, outputKey, description] = args;
+    this.workflow.registerOutput(name, description, this.outputs[outputKey]);
+    return this;
   }
 
   public addDependency(

--- a/packages/cdkactions/src/types.ts
+++ b/packages/cdkactions/src/types.ts
@@ -1,8 +1,10 @@
+import type { AnyExpression } from '#src/expressions.ts';
+
 /**
- * A generic string to string map.
+ * A generic string to string map. Values may be plain strings or expression proxies.
  */
 export interface StringMap {
-  readonly [key: string]: string;
+  readonly [key: string]: string | AnyExpression<string>;
 }
 
 /**

--- a/packages/cdkactions/src/utils.ts
+++ b/packages/cdkactions/src/utils.ts
@@ -1,11 +1,9 @@
-import type { StringMap } from '#src/types.ts';
-
 export type Writable<T> = T extends Function ? T : T extends object ? { -readonly [K in keyof T]: Writable<T[K]> } : T;
 
 /**
  * A helper function to recursively rename keys within an object
  */
-export const renameKeys = (obj: any, newKeys: StringMap) => {
+export const renameKeys = (obj: any, newKeys: Record<string, string>) => {
   if (obj === null) {
     return null;
   }

--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -267,7 +267,7 @@ export interface WorkflowCallSecretProps {
 
 export interface WorkflowCallOutputProps {
   readonly description: string;
-  readonly value: string;
+  readonly value: string | AnyExpression<string>;
 }
 
 export interface WorkflowCallEventProps {
@@ -383,6 +383,15 @@ export class Workflow<TOn extends WorkflowTrigger = WorkflowTrigger> extends Con
       name: this.action.name,
       on: this.action.on,
     }));
+  }
+
+  public registerOutput(name: string, description: string, value: string | AnyExpression<string>): void {
+    const on = this.action.on as any;
+    if (!on?.workflowCall) {
+      throw new Error('Workflow outputs are only supported on workflowCall triggers');
+    }
+    on.workflowCall.outputs ??= {};
+    on.workflowCall.outputs[name] = { description, value };
   }
 
   public addDependency(dependee: Workflow<any>) {

--- a/packages/cdkactions/test/action.test.ts
+++ b/packages/cdkactions/test/action.test.ts
@@ -181,25 +181,25 @@ test('multi-word camelCase keys convert correctly', () => {
   });
 });
 
-test('output() returns expression string for known output key', () => {
+test('output returns expression string for known output key', () => {
   const step = allOptionalAction({ id: 'co' });
-  const ref = step.output('ref');
-  expect(unwrapToken(ref as string)).toBe('steps.co.outputs.ref');
+  const ref = step.outputs.ref;
+  expect(unwrapToken(ref)).toBe('steps.co.outputs.ref');
 });
 
-test('output() returns expression for another known output key', () => {
+test('output returns expression for another known output key', () => {
   const step = allOptionalAction({ id: 'co' });
-  const commit = step.output('commit');
-  expect(unwrapToken(commit as string)).toBe('steps.co.outputs.commit');
+  const commit = step.outputs.commit;
+  expect(unwrapToken(commit)).toBe('steps.co.outputs.commit');
 });
 
-test('output() on uploadArtifact returns correct expression', () => {
+test('output on uploadArtifact returns correct expression', () => {
   const step = uploadArtifactV4({
     id: 'upload',
     with: { name: 'dist', path: 'dist/' },
   });
-  expect(unwrapToken(step.output('artifactId') as string)).toBe('steps.upload.outputs.artifactId');
-  expect(unwrapToken(step.output('artifactUrl') as string)).toBe('steps.upload.outputs.artifactUrl');
+  expect(unwrapToken(step.outputs.artifactId)).toBe('steps.upload.outputs.artifactId');
+  expect(unwrapToken(step.outputs.artifactUrl)).toBe('steps.upload.outputs.artifactUrl');
 });
 
 import {
@@ -238,7 +238,7 @@ test('setupNodeV6 produces correct uses and serializes inputs', () => {
 
 test('setupNodeV6 output returns expression', () => {
   const step = setupNodeV6({ id: 'node' });
-  expect(unwrapToken(step.output('cacheHit') as string)).toBe('steps.node.outputs.cacheHit');
+  expect(unwrapToken(step.outputs.cacheHit)).toBe('steps.node.outputs.cacheHit');
 });
 
 test('setupGoV6 ref is correct', () => {
@@ -319,10 +319,10 @@ console.log('\nType-level tests (compile-time checks):');
 
 const _validStep: TypedUsesStep<{ ref: {}; commit: {} }> = allOptionalAction({ id: 'co' });
 
-const _outputRef: Expression<string> = _validStep.output('ref');
+const _outputRef: Expression<string> = _validStep.outputs.ref;
 
 // @ts-expect-error — 'nonexistent' is not an output
-allOptionalAction({ id: 'co' }).output('nonexistent');
+allOptionalAction({ id: 'co' }).outputs.nonexistent;
 
 // @ts-expect-error — 'branchName' is not a valid input
 allOptionalAction({ id: 'co', with: { branchName: 'main' } });

--- a/packages/cdkactions/test/job.test.ts
+++ b/packages/cdkactions/test/job.test.ts
@@ -678,24 +678,24 @@ test('step if with Expression emits without ${{ }} wrapping', () => {
   expect(ghAction.steps[0].if).toBe("github.event_name == 'push'");
 });
 
-test('step() helper returns config with output() method', () => {
+test('step() helper returns config with output proxy', () => {
   const { step } = require('#src/index.ts');
   const s = step({ id: 'deploy', uses: 'actions/deploy-pages@v4' });
   expect(s.id).toBe('deploy');
   expect(s.uses).toBe('actions/deploy-pages@v4');
-  expect(unwrapToken(String(s.output('page_url')))).toBe('steps.deploy.outputs.page_url');
+  expect(unwrapToken(String(s.outputs.page_url))).toBe('steps.deploy.outputs.page_url');
 });
 
 test('step() output is non-enumerable', () => {
   const { step } = require('#src/index.ts');
   const s = step({ id: 'build', run: 'npm run build' });
-  expect(Object.keys(s)).not.toContain('output');
+  expect(Object.keys(s)).not.toContain('outputs');
 });
 
 test('step() output serializes correctly in resolveTokens', () => {
   const { step } = require('#src/index.ts');
   const s = step({ id: 'check', uses: 'actions/check@v1' });
-  const resolved = resolveTokens({ url: `${s.output('result')}` });
+  const resolved = resolveTokens({ url: `${s.outputs.result}` });
   expect((resolved as any).url).toBe('${{ steps.check.outputs.result }}');
 });
 


### PR DESCRIPTION
## Summary

- Rename step `output` method to `outputs` property (Proxy-based access matching GHA naming convention)
- Add `Job.outputs` proxy generating `jobs.<id>.outputs.<key>` expressions on property access
- Add `Job.addOutput(name, key, description)` to register workflow-level outputs on `workflowCall` triggers, type-guarded so it's only callable on workflowCall workflows
- Widen `StringMap`, `with`, `env`, and output value types to accept `AnyExpression` so context proxies (`github.actor`, `secrets.*`, etc.) can be used directly without template literal wrapping
- Update AGENTS.md with new patterns

## Test plan
- [x] All 187 tests pass
- [x] All 24 snapshots pass
- [x] Type-level tests verify `addOutput` is blocked on non-workflowCall workflows
- [x] Type-level tests verify `DeepExpression<string>` is assignable to `StringMap` values
- [x] `@ts-expect-error` annotations validate unknown output keys are caught