### PR TITLE
feat: add typed inputs proxy to Workflow class

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,15 @@ new Job(workflow, 'push', {
 
 ## Typed Action References
 
-Pre-defined actions enforce required inputs, reject unknown keys, and give typed `.output()` access — all at compile time.
+Pre-defined actions enforce required inputs, reject unknown keys, and give typed `.outputs` proxy access — all at compile time.
 
 ```typescript
 import { checkoutV4, uploadArtifactV4, setupNodeV6 } from '@factbird/cdkactions';
 
 // Callable — all-optional inputs means the parameter is optional
 const co = checkoutV4({ id: 'co', with: { fetchDepth: 0 } });
-co.output('commit'); // ✓ declared output
-// co.output('digest'); // ✗ compile error — not a declared output
+co.outputs.commit; // ✓ declared output
+// co.outputs.digest; // ✗ compile error — not a declared output
 
 // Required inputs are enforced
 const upload = uploadArtifactV4({
@@ -104,7 +104,7 @@ const upload = uploadArtifactV4({
 
 new Job(workflow, 'build', {
   runsOn: RunnerLabel.UBUNTU_LATEST,
-  outputs: { artifact_id: `${upload.output('artifactId')}` },
+  outputs: { artifact_id: `${upload.outputs.artifactId}` },
   steps: [co, setupNodeV6({ id: 'node', with: { nodeVersion: '22' } }), upload],
 });
 ```
@@ -127,7 +127,7 @@ const myAction = defineAction<
 | Matrix builds | Generic `StrategyProps<TMatrix>` with typed `matrix.<key>` access | [01-nodejs-ci-matrix.ts](packages/cdkactions/examples/01-nodejs-ci-matrix.ts) |
 | Docker build & push | Concurrency, permissions, context proxies for credentials | [02-docker-build-push.ts](packages/cdkactions/examples/02-docker-build-push.ts) |
 | Multi-job pipelines | Job dependencies, typed artifact upload/download, conditional deploy | [03-multi-job-pipeline.ts](packages/cdkactions/examples/03-multi-job-pipeline.ts) |
-| Manual dispatch | `workflowDispatch` with typed inputs (choice, boolean, environment) | [05-manual-dispatch.ts](packages/cdkactions/examples/05-manual-dispatch.ts) |
+| Manual dispatch | `workflowDispatch` with typed `workflow.inputs` proxy (choice, boolean, environment) | [05-manual-dispatch.ts](packages/cdkactions/examples/05-manual-dispatch.ts) |
 | Reusable workflows | `workflowCall` with inputs, outputs, and secrets | [06-reusable-workflow.ts](packages/cdkactions/examples/06-reusable-workflow.ts) |
 | Docker services | Container jobs with `command` and `entrypoint` | [07-container-services.ts](packages/cdkactions/examples/07-container-services.ts) |
 | Composite actions | Reusable multi-step actions as constructs | [08-composite-action.ts](packages/cdkactions/examples/08-composite-action.ts) |

--- a/packages/cdkactions/examples/05-manual-dispatch.ts
+++ b/packages/cdkactions/examples/05-manual-dispatch.ts
@@ -1,6 +1,6 @@
-import { App, Stack, Workflow, Job, RunnerLabel, WorkflowDispatchInputType, expression } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, WorkflowDispatchInputType, expression, eq } from '#src/index.ts';
 
-const { inputs, github } = expression;
+const { github } = expression;
 
 export function create(app?: App) {
   const _app = app ?? new App();
@@ -8,7 +8,7 @@ export function create(app?: App) {
 
   const workflow = new Workflow(stack, 'deploy-manual', {
     name: 'Manual Deploy',
-    runName: `Deploy ${inputs.environment} by ${github.actor}`,
+    runName: `Deploy by ${github.actor}`,
     on: {
       workflowDispatch: {
         inputs: {
@@ -42,7 +42,8 @@ export function create(app?: App) {
 
   new Job(workflow, 'deploy', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
-    steps: [{ name: 'Deploy', run: 'echo "Deploying..."' }],
+    if: eq(workflow.inputs.logLevel, 'debug'),
+    steps: [{ name: 'Deploy', run: `echo "Deploying to ${workflow.inputs.environment}"` }],
   });
 
   return _app;

--- a/packages/cdkactions/examples/17-type-level-tests.ts
+++ b/packages/cdkactions/examples/17-type-level-tests.ts
@@ -70,3 +70,38 @@ _checkoutV4({ id: 'x' }).outputs.digest;
 job.addOutput('hash', 'hash', 'Build hash');
 
 const _envMap: StringMap = { user: github.actor };
+
+// --- Workflow.inputs proxy type-level tests ---
+
+import { WorkflowDispatchInputType, eq, type WorkflowInputsProxy, type DeepExpression } from '#src/index.ts';
+
+const dispatchWorkflow = new Workflow(undefined as any, 'dispatch', {
+  name: 'Dispatch',
+  on: {
+    workflowDispatch: {
+      inputs: {
+        project: {
+          description: 'Project',
+          required: true,
+          type: WorkflowDispatchInputType.CHOICE,
+          options: ['app', 'api'],
+        },
+        dryRun: {
+          description: 'Dry run',
+          required: false,
+          type: WorkflowDispatchInputType.BOOLEAN,
+        },
+      },
+    },
+  },
+});
+
+// Valid input keys work
+const _project: DeepExpression<string> = dispatchWorkflow.inputs.project;
+const _dryRun: DeepExpression<string> = dispatchWorkflow.inputs.dryRun;
+
+// Works with eq without casts
+const _cond = eq(dispatchWorkflow.inputs.project, 'app');
+
+// @ts-expect-error — nonexistent input key
+dispatchWorkflow.inputs.nonexistent;

--- a/packages/cdkactions/examples/17-type-level-tests.ts
+++ b/packages/cdkactions/examples/17-type-level-tests.ts
@@ -71,8 +71,6 @@ job.addOutput('hash', 'hash', 'Build hash');
 
 const _envMap: StringMap = { user: github.actor };
 
-// --- Workflow.inputs proxy type-level tests ---
-
 import { WorkflowDispatchInputType, eq, type WorkflowInputsProxy, type DeepExpression } from '#src/index.ts';
 
 const dispatchWorkflow = new Workflow(undefined as any, 'dispatch', {
@@ -96,11 +94,8 @@ const dispatchWorkflow = new Workflow(undefined as any, 'dispatch', {
   },
 });
 
-// Valid input keys work
 const _project: DeepExpression<string> = dispatchWorkflow.inputs.project;
 const _dryRun: DeepExpression<string> = dispatchWorkflow.inputs.dryRun;
-
-// Works with eq without casts
 const _cond = eq(dispatchWorkflow.inputs.project, 'app');
 
 // @ts-expect-error — nonexistent input key

--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert';
 
 import { Construct, Node } from 'constructs';
 
-import type { AnyExpression } from '#src/expressions.ts';
+import type { AnyExpression, DeepExpression } from '#src/expressions.ts';
+import { expr } from '#src/expressions.ts';
 import { type ConcurrencyConfig, Job } from '#src/job.ts';
 import type { DefaultsProps, StringMap } from '#src/types.ts';
 import { camelToSnake, renameKeys, type Writable } from '#src/utils.ts';
@@ -351,6 +352,16 @@ export type WorkflowTrigger =
   | MergeGroupEvent
   | WorkflowCallEvent;
 
+type ExtractWorkflowInputs<TOn> = TOn extends { workflowDispatch: { inputs: infer I extends Record<string, any> } }
+  ? I
+  : TOn extends { workflowCall: { inputs: infer I extends Record<string, any> } }
+    ? I
+    : Record<string, unknown>;
+
+export type WorkflowInputsProxy<TOn> = {
+  readonly [K in keyof ExtractWorkflowInputs<TOn>]: DeepExpression<string>;
+};
+
 export interface WorkflowProps {
   readonly name: string;
   readonly runName?: string | AnyExpression<string>;
@@ -372,6 +383,7 @@ const whiteSeparators = /[\n\t]/g;
 
 export class Workflow<TOn extends WorkflowTrigger = WorkflowTrigger> extends Construct {
   public readonly outputFile: string;
+  public readonly inputs: WorkflowInputsProxy<TOn>;
   private readonly action: Writable<Omit<WorkflowProps, 'on'> & { on: TOn }>;
 
   public constructor(scope: Construct, id: string, config: Omit<WorkflowProps, 'on'> & { readonly on: TOn }) {
@@ -379,6 +391,12 @@ export class Workflow<TOn extends WorkflowTrigger = WorkflowTrigger> extends Con
     super(scope, id);
     this.action = config as Writable<Omit<WorkflowProps, 'on'> & { on: TOn }>;
     this.outputFile = `cdkactions_${sanitizedId}.yaml`;
+    this.inputs = new Proxy({} as WorkflowInputsProxy<TOn>, {
+      get(_target, prop: string | symbol): unknown {
+        if (typeof prop === 'symbol') return undefined;
+        return expr<string>(`inputs.${prop}`);
+      },
+    });
     addWorkflowValidation(this, () => ({
       name: this.action.name,
       on: this.action.on,

--- a/packages/cdkactions/src/workflow.ts
+++ b/packages/cdkactions/src/workflow.ts
@@ -2,8 +2,7 @@ import assert from 'node:assert';
 
 import { Construct, Node } from 'constructs';
 
-import type { AnyExpression, DeepExpression } from '#src/expressions.ts';
-import { expr } from '#src/expressions.ts';
+import { expr, type AnyExpression, type DeepExpression } from '#src/expressions.ts';
 import { type ConcurrencyConfig, Job } from '#src/job.ts';
 import type { DefaultsProps, StringMap } from '#src/types.ts';
 import { camelToSnake, renameKeys, type Writable } from '#src/utils.ts';

--- a/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
+++ b/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
@@ -210,13 +210,14 @@ on:
           - error
         required: true
         type: choice
-run-name: Deploy \${{ inputs.environment }} by \${{ github.actor }}
+run-name: Deploy by \${{ github.actor }}
 jobs:
   deploy:
+    if: inputs.logLevel == 'debug'
     runs-on: ubuntu-latest
     steps:
       - name: Deploy
-        run: echo "Deploying..."
+        run: echo "Deploying to \${{ inputs.environment }}"
 "
 ,
 }

--- a/packages/cdkactions/test/workflow.test.ts
+++ b/packages/cdkactions/test/workflow.test.ts
@@ -460,6 +460,40 @@ test('workflow concurrency string form', () => {
   expect(ghAction.concurrency).toBe('deploy-group');
 });
 
+test('workflow inputs proxy generates correct expressions for workflowDispatch', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      workflowDispatch: {
+        inputs: {
+          environment: {
+            description: 'Target environment',
+            required: true,
+            type: WorkflowDispatchInputType.STRING,
+          },
+        },
+      },
+    },
+  });
+  expect(String(workflow.inputs.environment)).toContain('inputs.environment');
+});
+
+test('workflow inputs proxy generates correct expressions for workflowCall', () => {
+  const workflow = TestingWorkflow({
+    on: {
+      workflowCall: {
+        inputs: {
+          nodeVersion: {
+            description: 'Node.js version',
+            required: true,
+            type: WorkflowDispatchInputType.STRING,
+          },
+        },
+      },
+    },
+  });
+  expect(String(workflow.inputs.nodeVersion)).toContain('inputs.nodeVersion');
+});
+
 test('workflow concurrency object with cancelInProgress', () => {
   const workflow = TestingWorkflow({
     on: 'push',


### PR DESCRIPTION
## Summary
- Adds `WorkflowInputsProxy<TOn>` type that infers input keys from `workflowDispatch` or `workflowCall` trigger config
- Adds `public readonly inputs` proxy to `Workflow` class, following the same pattern as `Job.outputs`
- Enables `this.inputs.project` with full type safety instead of the untyped global `inputs` proxy (no more `as Expression<string>` casts)

## Test plan
- [x] All 187 existing tests pass
- [x] Type-level verification: `wf.inputs.project` resolves to `DeepExpression<string>`, works with `eq()` without casts, and `wf.inputs.nonexistent` correctly errors