### PR TITLE
Typed construct-level proxies and cleanup global contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ Organizations define all their action references in a shared module (e.g., `acti
 
 Expressions are branded strings (`Expression<T>`) with a phantom type parameter tracking the runtime value type. They are zero-cost at runtime — no AST, no parsing.
 
-Context accessors (e.g., `github`, `runner`, `secrets`, `matrix`) use `Proxy` objects created once at module load to generate expression strings like `github.ref` on property access.
+Context accessors (e.g., `github`, `runner`, `secrets`) use `Proxy` objects created once at module load to generate expression strings like `github.ref` on property access. `inputs` and `matrix` are not global — they are typed construct-level proxies on `Workflow.inputs` and `Job.matrix` respectively, inferred from the construct's configuration.
 
 All expression functions and context proxies are available via the `expression` namespace:
 

--- a/packages/cdkactions/examples/01-nodejs-ci-matrix.ts
+++ b/packages/cdkactions/examples/01-nodejs-ci-matrix.ts
@@ -1,7 +1,5 @@
-import { App, Stack, Workflow, Job, RunnerLabel, expression } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, createMatrixProxy } from '#src/index.ts';
 import { checkoutV4, setupNodeV6 } from '#src/actions.ts';
-
-const { matrix } = expression;
 
 export function create(app?: App) {
   const _app = app ?? new App();
@@ -15,17 +13,18 @@ export function create(app?: App) {
     },
   });
 
+  const matrixDef = { nodeVersion: ['18', '20', '22'] } as const;
+  const m = createMatrixProxy(matrixDef);
+
   new Job(workflow, 'build', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
     strategy: {
-      matrix: {
-        nodeVersion: ['18', '20', '22'] as const,
-      },
+      matrix: matrixDef,
       failFast: false,
     },
     steps: [
       checkoutV4(),
-      setupNodeV6({ id: 'setup-node', with: { nodeVersion: `${matrix.nodeVersion}` } }),
+      setupNodeV6({ id: 'setup-node', with: { nodeVersion: `${m.nodeVersion}` } }),
       { name: 'Install', run: 'npm ci' },
       { name: 'Lint', run: 'npm run lint' },
       { name: 'Test', run: 'npm test' },

--- a/packages/cdkactions/examples/01-nodejs-ci-matrix.ts
+++ b/packages/cdkactions/examples/01-nodejs-ci-matrix.ts
@@ -1,4 +1,4 @@
-import { App, Stack, Workflow, Job, RunnerLabel, createMatrixProxy } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel } from '#src/index.ts';
 import { checkoutV4, setupNodeV6 } from '#src/actions.ts';
 
 export function create(app?: App) {
@@ -13,18 +13,17 @@ export function create(app?: App) {
     },
   });
 
-  const matrixDef = { nodeVersion: ['18', '20', '22'] } as const;
-  const m = createMatrixProxy(matrixDef);
-
   new Job(workflow, 'build', {
     runsOn: RunnerLabel.UBUNTU_LATEST,
     strategy: {
-      matrix: matrixDef,
+      matrix: {
+        nodeVersion: ['18', '20', '22'] as const,
+      },
       failFast: false,
     },
     steps: [
       checkoutV4(),
-      setupNodeV6({ id: 'setup-node', with: { nodeVersion: `${m.nodeVersion}` } }),
+      (matrix) => setupNodeV6({ id: 'setup-node', with: { nodeVersion: `${matrix.nodeVersion}` } }),
       { name: 'Install', run: 'npm ci' },
       { name: 'Lint', run: 'npm run lint' },
       { name: 'Test', run: 'npm test' },

--- a/packages/cdkactions/examples/01-nodejs-ci-matrix.ts
+++ b/packages/cdkactions/examples/01-nodejs-ci-matrix.ts
@@ -21,9 +21,9 @@ export function create(app?: App) {
       },
       failFast: false,
     },
-    steps: [
+    steps: (matrix) => [
       checkoutV4(),
-      (matrix) => setupNodeV6({ id: 'setup-node', with: { nodeVersion: `${matrix.nodeVersion}` } }),
+      setupNodeV6({ id: 'setup-node', with: { nodeVersion: `${matrix.nodeVersion}` } }),
       { name: 'Install', run: 'npm ci' },
       { name: 'Lint', run: 'npm run lint' },
       { name: 'Test', run: 'npm test' },

--- a/packages/cdkactions/examples/12-multi-platform-runner-groups.ts
+++ b/packages/cdkactions/examples/12-multi-platform-runner-groups.ts
@@ -1,4 +1,4 @@
-import { App, Stack, Workflow, Job, RunnerLabel, createMatrixProxy } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel } from '#src/index.ts';
 import { checkoutV4 } from '#src/actions.ts';
 
 export function create(app?: App) {
@@ -10,22 +10,19 @@ export function create(app?: App) {
     on: { push: { branches: ['main'] } },
   });
 
-  const matrixDef = {
-    os: ['ubuntu-latest', 'macos-latest', 'windows-latest'],
-    arch: ['x64', 'arm64'],
-  } as const;
-  const m = createMatrixProxy(matrixDef);
-
   new Job(workflow, 'build', {
     runsOn: { group: 'large-runners', labels: [RunnerLabel.custom('linux-x64-8core')] },
     strategy: {
-      matrix: matrixDef,
+      matrix: {
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest'] as const,
+        arch: ['x64', 'arm64'] as const,
+      },
       failFast: false,
       maxParallel: 4,
     },
     continueOnError: true,
     timeoutMinutes: 60,
-    steps: [checkoutV4(), { name: 'Build', run: `make build ARCH=${m.arch}` }],
+    steps: [checkoutV4(), (matrix) => ({ name: 'Build', run: `make build ARCH=${matrix.arch}` })],
   });
 
   return _app;

--- a/packages/cdkactions/examples/12-multi-platform-runner-groups.ts
+++ b/packages/cdkactions/examples/12-multi-platform-runner-groups.ts
@@ -1,7 +1,5 @@
-import { App, Stack, Workflow, Job, RunnerLabel, expression } from '#src/index.ts';
+import { App, Stack, Workflow, Job, RunnerLabel, createMatrixProxy } from '#src/index.ts';
 import { checkoutV4 } from '#src/actions.ts';
-
-const { matrix } = expression;
 
 export function create(app?: App) {
   const _app = app ?? new App();
@@ -12,19 +10,22 @@ export function create(app?: App) {
     on: { push: { branches: ['main'] } },
   });
 
+  const matrixDef = {
+    os: ['ubuntu-latest', 'macos-latest', 'windows-latest'],
+    arch: ['x64', 'arm64'],
+  } as const;
+  const m = createMatrixProxy(matrixDef);
+
   new Job(workflow, 'build', {
     runsOn: { group: 'large-runners', labels: [RunnerLabel.custom('linux-x64-8core')] },
     strategy: {
-      matrix: {
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest'] as const,
-        arch: ['x64', 'arm64'] as const,
-      },
+      matrix: matrixDef,
       failFast: false,
       maxParallel: 4,
     },
     continueOnError: true,
     timeoutMinutes: 60,
-    steps: [checkoutV4(), { name: 'Build', run: `make build ARCH=${matrix.arch}` }],
+    steps: [checkoutV4(), { name: 'Build', run: `make build ARCH=${m.arch}` }],
   });
 
   return _app;

--- a/packages/cdkactions/examples/12-multi-platform-runner-groups.ts
+++ b/packages/cdkactions/examples/12-multi-platform-runner-groups.ts
@@ -22,7 +22,7 @@ export function create(app?: App) {
     },
     continueOnError: true,
     timeoutMinutes: 60,
-    steps: [checkoutV4(), (matrix) => ({ name: 'Build', run: `make build ARCH=${matrix.arch}` })],
+    steps: (matrix) => [checkoutV4(), { name: 'Build', run: `make build ARCH=${matrix.arch}` }],
   });
 
   return _app;

--- a/packages/cdkactions/src/expressions.ts
+++ b/packages/cdkactions/src/expressions.ts
@@ -210,11 +210,6 @@ export interface SecretsContext {
   readonly [key: string]: DeepExpression<string>;
 }
 
-export interface MatrixContext {
-  /** Access a matrix variable by name. */
-  readonly [key: string]: DeepExpression<unknown>;
-}
-
 export interface NeedsContext {
   /** Access a dependent job's context by job ID. */
   readonly [key: string]: DeepExpression<{
@@ -230,11 +225,6 @@ export interface StepsContext {
     readonly outcome: string;
     readonly conclusion: string;
   }>;
-}
-
-export interface InputsContext {
-  /** Access a workflow input by name. */
-  readonly [key: string]: DeepExpression<string>;
 }
 
 export interface VarsContext {
@@ -360,17 +350,11 @@ export const env: EnvContext = createContextProxy<EnvContext>('env');
 /** Secrets context. Keys are passed through as-is. */
 export const secrets: SecretsContext = createContextProxy<SecretsContext>('secrets');
 
-/** Matrix context — current matrix combination values. Keys are passed through as-is. */
-export const matrix: MatrixContext = createContextProxy<MatrixContext>('matrix');
-
 /** Needs context — outputs and results of dependent jobs. Keys are passed through as-is. */
 export const needs: NeedsContext = createContextProxy<NeedsContext>('needs');
 
 /** Steps context — outputs and status of previous steps. Keys are passed through as-is. */
 export const steps: StepsContext = createContextProxy<StepsContext>('steps');
-
-/** Inputs context — workflow dispatch or reusable workflow inputs. Keys are passed through as-is. */
-export const inputs: InputsContext = createContextProxy<InputsContext>('inputs');
 
 /** Configuration variables context. Keys are passed through as-is. */
 export const vars: VarsContext = createContextProxy<VarsContext>('vars');
@@ -542,10 +526,8 @@ export const expression = Object.assign(expr, {
   runner,
   env,
   secrets,
-  matrix,
   needs,
   steps,
-  inputs,
   vars,
   job,
   strategy,

--- a/packages/cdkactions/src/job.ts
+++ b/packages/cdkactions/src/job.ts
@@ -72,10 +72,6 @@ export interface UsesStep<TOn = unknown> extends StepBase<TOn> {
 
 export type StepConfig<TOn = unknown> = RunStep<TOn> | UsesStep<TOn>;
 
-export type StepEntry<TMatrix extends MatrixDefinition = MatrixDefinition, TOn = unknown> =
-  | StepConfig<TOn>
-  | ((matrix: MatrixProxy<TMatrix>) => StepConfig<TOn>);
-
 /** @deprecated Use StepConfig instead. */
 export type StepsProps = StepConfig;
 
@@ -143,7 +139,7 @@ export interface JobProps<
   readonly env?: StringMap;
   readonly defaults?: DefaultsProps;
   readonly if?: IfCondition<TOn>;
-  readonly steps?: StepEntry<TMatrix, TOn>[];
+  readonly steps?: StepConfig<TOn>[] | ((matrix: MatrixProxy<TMatrix>) => StepConfig<TOn>[]);
   readonly secrets?: Record<string, string | AnyExpression<string>> | 'inherit';
   readonly timeoutMinutes?: number;
   readonly strategy?: StrategyProps<TMatrix>;
@@ -207,12 +203,19 @@ export class Job<
     return this.action.name;
   }
 
+  private resolveSteps(): StepConfig<TOn>[] {
+    const steps = this.action.steps;
+    if (!steps) return [];
+    if (typeof steps === 'function') return steps(this.matrix);
+    return steps as StepConfig<TOn>[];
+  }
+
   get steps(): StepConfig<TOn>[] {
-    return (this.action.steps || []).map((s) => (typeof s === 'function' ? s(this.matrix) : s)) as StepConfig<TOn>[];
+    return this.resolveSteps();
   }
 
   public toGHAction(): any {
-    const { uses, runsOn, steps, strategy, if: propsIf, ...rest } = this.action;
+    const { uses, runsOn, steps: _steps, strategy, if: propsIf, ...rest } = this.action;
 
     const resolvedIf = typeof propsIf === 'function' ? propsIf(github as any) : propsIf;
     const conditions = [this.if, resolvedIf].filter((c): c is AnyExpression<boolean> => c !== undefined);
@@ -248,16 +251,19 @@ export class Job<
       };
     }
 
-    const serializedSteps = steps?.map((s) => {
-      const resolved = typeof s === 'function' ? s(this.matrix) : s;
-      const { if: stepIf, ...stepRest } = resolved;
-      const resolvedStepIf = typeof stepIf === 'function' ? stepIf(github as any) : stepIf;
-      const serialized = renameKeys(stepRest, keyMap);
-      return {
-        ...serialized,
-        ...(resolvedStepIf !== undefined ? { if: resolvedStepIf } : {}),
-      };
-    });
+    const resolvedSteps = this.resolveSteps();
+    const serializedSteps =
+      resolvedSteps.length > 0
+        ? resolvedSteps.map((s) => {
+            const { if: stepIf, ...stepRest } = s;
+            const resolvedStepIf = typeof stepIf === 'function' ? stepIf(github as any) : stepIf;
+            const serialized = renameKeys(stepRest, keyMap);
+            return {
+              ...serialized,
+              ...(resolvedStepIf !== undefined ? { if: resolvedStepIf } : {}),
+            };
+          })
+        : undefined;
 
     let serializedStrategy: Record<string, unknown> | undefined;
     if (strategy) {

--- a/packages/cdkactions/src/job.ts
+++ b/packages/cdkactions/src/job.ts
@@ -72,6 +72,10 @@ export interface UsesStep<TOn = unknown> extends StepBase<TOn> {
 
 export type StepConfig<TOn = unknown> = RunStep<TOn> | UsesStep<TOn>;
 
+export type StepEntry<TMatrix extends MatrixDefinition = MatrixDefinition, TOn = unknown> =
+  | StepConfig<TOn>
+  | ((matrix: MatrixProxy<TMatrix>) => StepConfig<TOn>);
+
 /** @deprecated Use StepConfig instead. */
 export type StepsProps = StepConfig;
 
@@ -139,7 +143,7 @@ export interface JobProps<
   readonly env?: StringMap;
   readonly defaults?: DefaultsProps;
   readonly if?: IfCondition<TOn>;
-  readonly steps?: StepConfig<TOn>[];
+  readonly steps?: StepEntry<TMatrix, TOn>[];
   readonly secrets?: Record<string, string | AnyExpression<string>> | 'inherit';
   readonly timeoutMinutes?: number;
   readonly strategy?: StrategyProps<TMatrix>;
@@ -204,7 +208,7 @@ export class Job<
   }
 
   get steps(): StepConfig<TOn>[] {
-    return (this.action.steps || []) as StepConfig<TOn>[];
+    return (this.action.steps || []).map((s) => (typeof s === 'function' ? s(this.matrix) : s)) as StepConfig<TOn>[];
   }
 
   public toGHAction(): any {
@@ -245,7 +249,8 @@ export class Job<
     }
 
     const serializedSteps = steps?.map((s) => {
-      const { if: stepIf, ...stepRest } = s;
+      const resolved = typeof s === 'function' ? s(this.matrix) : s;
+      const { if: stepIf, ...stepRest } = resolved;
       const resolvedStepIf = typeof stepIf === 'function' ? stepIf(github as any) : stepIf;
       const serialized = renameKeys(stepRest, keyMap);
       return {

--- a/packages/cdkactions/src/library.ts
+++ b/packages/cdkactions/src/library.ts
@@ -3,7 +3,7 @@ import { dedent } from 'ts-dedent';
 
 import { checkoutV4 } from '#src/actions.ts';
 import { always, expr, github, secrets } from '#src/expressions.ts';
-import { Job, type JobProps, type MatrixDefinition, type StepEntry } from '#src/job.ts';
+import { Job, type JobProps, type MatrixDefinition } from '#src/job.ts';
 import { RunnerLabel } from '#src/nominal.ts';
 import { Stack } from '#src/stack.ts';
 import { Workflow } from '#src/workflow.ts';
@@ -59,8 +59,10 @@ export class CDKActionsStack extends Stack {
  */
 export class CheckoutJob<TMatrix extends MatrixDefinition = MatrixDefinition> extends Job<TMatrix> {
   public constructor(scope: Workflow, id: string, config: JobProps<TMatrix>) {
-    const checkoutStep: StepEntry<TMatrix> = checkoutV4();
-    const steps: StepEntry<TMatrix>[] = [checkoutStep, ...(config.steps || [])];
-    super(scope, id, { ...config, steps });
+    const { steps: configSteps, ...rest } = config;
+    const co = checkoutV4();
+    const steps: JobProps<TMatrix>['steps'] =
+      typeof configSteps === 'function' ? (matrix) => [co, ...configSteps(matrix)] : [co, ...(configSteps || [])];
+    super(scope, id, { ...rest, steps });
   }
 }

--- a/packages/cdkactions/src/library.ts
+++ b/packages/cdkactions/src/library.ts
@@ -3,7 +3,7 @@ import { dedent } from 'ts-dedent';
 
 import { checkoutV4 } from '#src/actions.ts';
 import { always, expr, github, secrets } from '#src/expressions.ts';
-import { Job, type JobProps, type MatrixDefinition, type StepConfig } from '#src/job.ts';
+import { Job, type JobProps, type MatrixDefinition, type StepEntry } from '#src/job.ts';
 import { RunnerLabel } from '#src/nominal.ts';
 import { Stack } from '#src/stack.ts';
 import { Workflow } from '#src/workflow.ts';
@@ -59,8 +59,8 @@ export class CDKActionsStack extends Stack {
  */
 export class CheckoutJob<TMatrix extends MatrixDefinition = MatrixDefinition> extends Job<TMatrix> {
   public constructor(scope: Workflow, id: string, config: JobProps<TMatrix>) {
-    const checkoutStep: StepConfig = checkoutV4();
-    const steps: StepConfig[] = [checkoutStep, ...(config.steps || [])];
+    const checkoutStep: StepEntry<TMatrix> = checkoutV4();
+    const steps: StepEntry<TMatrix>[] = [checkoutStep, ...(config.steps || [])];
     super(scope, id, { ...config, steps });
   }
 }

--- a/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
+++ b/packages/cdkactions/test/__snapshots__/examples.test.ts.snap
@@ -337,7 +337,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps: []
 "
 ,
 }

--- a/packages/cdkactions/test/expressions.test.ts
+++ b/packages/cdkactions/test/expressions.test.ts
@@ -15,12 +15,10 @@ import {
   gt,
   gte,
   hashFiles,
-  inputs,
   job,
   join,
   lt,
   lte,
-  matrix,
   needs,
   neq,
   not,
@@ -84,11 +82,6 @@ test('secrets context returns correct expression strings', () => {
   expect(raw(secrets.MY_SECRET)).toBe('secrets.MY_SECRET');
 });
 
-test('matrix context returns correct expression strings', () => {
-  expect(raw(matrix.os)).toBe('matrix.os');
-  expect(raw(matrix.node)).toBe('matrix.node');
-});
-
 test('needs context returns correct expression strings', () => {
   expect(raw(needs.build)).toBe('needs.build');
   expect(raw(needs.test)).toBe('needs.test');
@@ -97,11 +90,6 @@ test('needs context returns correct expression strings', () => {
 test('steps context returns correct expression strings', () => {
   expect(raw(steps.checkout)).toBe('steps.checkout');
   expect(raw(steps.build)).toBe('steps.build');
-});
-
-test('inputs context returns correct expression strings', () => {
-  expect(raw(inputs.environment)).toBe('inputs.environment');
-  expect(raw(inputs.dryRun)).toBe('inputs.dryRun');
 });
 
 test('vars context returns correct expression strings', () => {
@@ -172,12 +160,12 @@ test('format produces correct expression', () => {
 });
 
 test('join produces correct expression without separator', () => {
-  const arr = matrix.os as unknown as Expression<string[]>;
+  const arr = expr<string[]>('matrix.os');
   expect(raw(join(arr))).toBe('join(matrix.os)');
 });
 
 test('join produces correct expression with separator', () => {
-  const arr = matrix.os as unknown as Expression<string[]>;
+  const arr = expr<string[]>('matrix.os');
   expect(raw(join(arr, ', '))).toBe("join(matrix.os, ', ')");
 });
 


### PR DESCRIPTION
## Summary

- Add typed `Workflow.inputs` proxy that infers input keys from `workflowDispatch`/`workflowCall` trigger config
- Remove global `inputs` and `matrix` context proxies — these are now construct-level: `Workflow.inputs` and `Job.matrix`
- Support `steps` as a function `(matrix) => StepConfig[]` for typed matrix access and step output references via variable bindings
- Fix `DeepExpression<any>` distribution and event payload index signatures
- Update README to reflect `.outputs` proxy API (replacing `.output('key')`)

## Test plan

- [x] Type-level tests for `Workflow.inputs` proxy (example 17)
- [x] Runtime tests for `Workflow.inputs` with `workflowDispatch` and `workflowCall` triggers
- [x] Examples 01, 05, 12 updated to use new APIs
- [x] All 187 tests pass, snapshots updated